### PR TITLE
Black ruff mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Contributions and feedbacks are highly welcome.
 A quick sample to read all values from the default database:
 
 ```python
+from mdbx import Env
+
 with Env(...) as env:
     with env.ro_transaction() as txn:
         with txn.cursor() as cur:

--- a/mdbx/__init__.py
+++ b/mdbx/__init__.py
@@ -1,4 +1,17 @@
-from .mdbx import Env, Geometry, MDBXTXNFlags, MDBXError, \
-    MDBXOption, Cursor, MDBXCursorOp, MDBXDBFlags, MDBXEnvFlags, \
-    MDBXStat, MDBXErrorExc, MDBXEnvinfo, MDBXCopyMode, \
-    get_version_info, get_build_info
+from .mdbx import (
+    Env,
+    Geometry,
+    MDBXTXNFlags,
+    MDBXError,
+    MDBXOption,
+    Cursor,
+    MDBXCursorOp,
+    MDBXDBFlags,
+    MDBXEnvFlags,
+    MDBXStat,
+    MDBXErrorExc,
+    MDBXEnvinfo,
+    MDBXCopyMode,
+    get_version_info,
+    get_build_info,
+)

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -3501,7 +3501,7 @@ _lib.mdbx_limits_dbsize_max.restype = ctypes.POINTER(ctypes.c_int)
 _lib.mdbx_limits_dbsize_min.argtypes = [ctypes.POINTER(ctypes.c_int)]
 _lib.mdbx_limits_dbsize_min.restype = ctypes.POINTER(ctypes.c_int)
 
-_lib.mdbx_limits_keysize_max.argtypes = [ctypes.POINTER(ctypes.c_int), MDBXDBFlags]
+_lib.mdbx_limits_keysize_max.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_uint]
 _lib.mdbx_limits_keysize_max.restype = ctypes.POINTER(ctypes.c_int)
 
 _lib.mdbx_limits_pgsize_max.argtypes = []
@@ -3513,7 +3513,7 @@ _lib.mdbx_limits_pgsize_min.restype = ctypes.POINTER(ctypes.c_int)
 _lib.mdbx_limits_txnsize_max.argtypes = [ctypes.POINTER(ctypes.c_int)]
 _lib.mdbx_limits_txnsize_max.restype = ctypes.POINTER(ctypes.c_int)
 
-_lib.mdbx_limits_valsize_max.argtypes = [ctypes.POINTER(ctypes.c_int), MDBXDBFlags]
+_lib.mdbx_limits_valsize_max.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_uint]
 _lib.mdbx_limits_valsize_max.restype = ctypes.POINTER(ctypes.c_int)
 
 

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1987,7 +1987,7 @@ class Env(object):
     def __init__(
         self,
         path: str,
-        flags: MDBXEnvFlags = 0,
+        flags: MDBXEnvFlags = MDBXEnvFlags.MDBX_ENV_DEFAULTS,
         mode: MDBXMode = 0o755,
         geometry: Optional[Geometry] = None,
         maxreaders: int = 1,

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2737,13 +2737,6 @@ class Cursor:
         if txn:
             txn._dependents.append(weakref.ref(self))
 
-    def dbi(self):
-        """
-        :returns internal DBI object
-        :rtype DBI
-        """
-        return self._db
-
     def bind(self, txn: TXN, db: DBI = None):
         """
         Thin wrapper around mdbx_cursor_bind

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -25,7 +25,8 @@ import os
 from pathlib import Path
 import sys
 import itertools
-from typing import Optional, Tuple, Iterator, List, Any, Callable
+from types import TracebackType
+from typing import Optional, Iterator, Any, Callable, Type, Literal
 from _ctypes import _Pointer
 from weakref import ReferenceType
 import weakref
@@ -684,7 +685,7 @@ class MDBXTXNFlags(enum.IntFlag):
 
 class MDBXDBFlags(enum.IntFlag):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     MDBX_DB_DEFAULTS = 0
@@ -729,7 +730,7 @@ class MDBXDBFlags(enum.IntFlag):
 
 class MDBXPutFlags(enum.IntFlag):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     # Upsertion by default (without any other flags)
@@ -790,7 +791,7 @@ class MDBXCopyFlags(enum.IntFlag):
 
 class MDBXCursorOp(enum.IntEnum):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     # Position at first key/data item
@@ -1016,7 +1017,7 @@ class MDBXError(enum.IntFlag):
 
 class MDBXOption(enum.IntEnum):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     MDBX_opt_max_db = 0
@@ -1035,7 +1036,7 @@ class MDBXOption(enum.IntEnum):
 
 class MDBXEnvDeleteMode(enum.IntEnum):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     MDBX_ENV_JUST_DELETE = 0
@@ -1052,7 +1053,7 @@ class MDBXDBIState(enum.IntFlag):
 
 class MDBXPageType(enum.IntEnum):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     MDBX_page_broken = 0
@@ -1068,7 +1069,7 @@ class MDBXPageType(enum.IntEnum):
 
 class MDBXCopyMode(enum.IntEnum):
 
-    def from_param(self):
+    def from_param(self) -> int:
         return int(self)
 
     MDBX_CP_DEFAULTS = 0
@@ -1103,7 +1104,7 @@ class MDBXBuildInfo(ctypes.Structure):
         ("flags", ctypes.c_char_p),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "datetime": self.datetime,
@@ -1145,7 +1146,7 @@ class MDBXVersionInfo(ctypes.Structure):
         ("sourcery", ctypes.c_char_p),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "major": self.major,
@@ -1187,7 +1188,7 @@ class MDBXStat(ctypes.Structure):
         ("ms_mod_txnid", ctypes.c_uint64),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "ms_psize": self.ms_psize,
@@ -1222,7 +1223,7 @@ class MDBXMiGeo(ctypes.Structure):
         ("grow", ctypes.c_uint64),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "lower": self.lower,
@@ -1237,28 +1238,28 @@ class MDBXMiGeo(ctypes.Structure):
 class MDBXEnvinfoCurrent(ctypes.Structure):
     _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfoMeta0(ctypes.Structure):
     _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfoMeta1(ctypes.Structure):
     _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfoMeta2(ctypes.Structure):
     _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"x": self.x, "y": self.y})
 
 
@@ -1270,7 +1271,7 @@ class MDBXEnvinfo_mi_bootid(ctypes.Structure):
         ("meta2", MDBXEnvinfoMeta2),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "current": self.current,
@@ -1385,7 +1386,7 @@ class MDBXEnvinfo(ctypes.Structure):
         ("mi_mode", ctypes.c_uint32),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "MDBXMiGeo": self.MDBXMiGeo,
@@ -1449,7 +1450,7 @@ class MDBXCommitLatency(ctypes.Structure):
         ("whole", ctypes.c_uint32),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "preparation": self.preparation,
@@ -1481,7 +1482,7 @@ class MDBXCanary(ctypes.Structure):
         ("v", ctypes.c_uint64),
     ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"x": self.x, "y": self.y, "z": self.z, "v": self.v})
 
 
@@ -1526,7 +1527,7 @@ class Iovec(ctypes.Structure):
                 ctypes.cast(self.iov_base, ctypes.POINTER(ctypes.c_ubyte))[:length]
             )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "iovec{.iov_base=%s, iov.len=%s}" % (self.iov_base, self.iov_len)
 
 
@@ -1561,7 +1562,7 @@ class MDBXDBI(ctypes.Structure):
 
     _fields_ = [("dbi", ctypes.c_uint32)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"dbi": self.dbi})
 
 
@@ -1572,7 +1573,7 @@ class MDBXAttr(ctypes.Structure):
 
     _fields_ = [("attr", ctypes.c_uint64)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str({"attr": self.attr})
 
 
@@ -1600,7 +1601,7 @@ class TXN:
     """
 
     def __init__(
-        self, env: Env, parent: Optional[TXN] = None, flags: MDBXTXNFlags = MDBXTXNFlags.MDBX_TXN_READWRITE, ctx: Optional[Any] = None
+        self, env: Env, parent: Optional[TXN] = None, flags: int = MDBXTXNFlags.MDBX_TXN_READWRITE, ctx: Optional[Any] = None
     ):
         """
 
@@ -1618,7 +1619,7 @@ class TXN:
         self._env: Env | None = env
         self._ctx: Optional[Any] = ctx
         self._flags = flags
-        self._dependents: List[ReferenceType[Cursor]] = []
+        self._dependents: list[ReferenceType[Cursor]] = []
         env._dependents.append(weakref.ref(self))
         ret = _lib.mdbx_txn_begin_ex(
             env._env, parent, flags, ctypes.pointer(self._txn), self._ctx
@@ -1626,22 +1627,25 @@ class TXN:
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
-    def __del__(self):
+    def __del__(self) -> None:
         logging.getLogger(__name__).debug(
             f"Transaction {self._txn} being deleted, dependents: {self._dependents}"
         )
         self.close()
 
-    def __enter__(self):
+    def __enter__(self) -> TXN:
         return self
 
-    def __exit__(self, _1, _2, _3):
+    def __exit__(self, exception_type: Optional[Type[BaseException]],
+                 exception_value: Optional[BaseException],
+                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
         logging.getLogger(__name__).debug(
             f"Transaction {self._txn} exits, dependents: {self._dependents}"
         )
         self.close()
+        return False
 
-    def break_txn(self):
+    def break_txn(self) -> bool:
         """
         Thin wrapper around mdbx_txn_break
 
@@ -1654,7 +1658,7 @@ class TXN:
             raise make_exception(ret)
         return True
 
-    def commit(self):
+    def commit(self) -> bool:
         """
         Thin wrapper around mdbx_txn_commit
 
@@ -1706,7 +1710,7 @@ class TXN:
         """
         return _lib.mdbx_txn_id(self._txn)
 
-    def get_env(self):
+    def get_env(self) -> Env | None:
         """
         Returns a reference to the Env object for which this TXN is valid
 
@@ -1726,7 +1730,7 @@ class TXN:
         """
         self._ctx = ctx
 
-    def set_user_ctx_int(self, ctx: ctypes.c_void_p):
+    def set_user_ctx_int(self, ctx: ctypes.c_void_p) -> bool:
         """
         Thin wrapper around mdbx_txn_set_userctx
 
@@ -1766,7 +1770,7 @@ class TXN:
             return _lib.mdbx_txn_get_userctx(self._txn)
         raise RuntimeError("TXN is not available")
 
-    def renew(self):
+    def renew(self) -> bool:
         """
         Thin wrapper around mdbx_txn_renew
         Renews the TXN
@@ -1782,7 +1786,7 @@ class TXN:
             return True
         raise RuntimeError("TXN is not available")
 
-    def reset(self):
+    def reset(self) -> bool:
         """
         Thin wrapper around mdbx_txn_reset
         Resets the TXN
@@ -1798,19 +1802,19 @@ class TXN:
             return True
         raise RuntimeError("TXN is not available")
 
-    def __inform_deps(self):
-        for cur in self._dependents:
-            cur = cur()
+    def __inform_deps(self) -> None:
+        for cur_ref in self._dependents:
+            cur = cur_ref()
             if cur is not None:
                 cur.close()
         self._dependents = []
 
-    def close(self):
+    def close(self) -> None:
         if self._txn:
             # The transaction is still alive, we must abort it
             self.abort()
 
-    def abort(self):
+    def abort(self) -> bool:
         """
         Thin wrapper around mdbx_txn_abort
         Aborts the TXN
@@ -1836,8 +1840,8 @@ class TXN:
     def create_map(
         self,
         name: Optional[str | bytes | None] = None,
-        flags: MDBXDBFlags = MDBXDBFlags.MDBX_CREATE,
-    ):
+        flags: int = MDBXDBFlags.MDBX_CREATE,
+    ) -> DBI:
         """
         Wrapper around mdbx_dbi_open, intended to create a database(map)
 
@@ -1854,7 +1858,7 @@ class TXN:
     def open_map(
         self,
         name: Optional[str | bytes | None] = None,
-        flags: MDBXDBFlags = MDBXDBFlags.MDBX_DB_DEFAULTS,
+        flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS,
     ) -> DBI:
         """
         Wrapper around mdbx_dbi_open, intended to open an existing map
@@ -1917,7 +1921,7 @@ class TXN:
             raise make_exception(ret)
         return canary
 
-    def put_canary(self, canary: MDBXCanary):
+    def put_canary(self, canary: MDBXCanary) -> None:
         """
         Thin wrapper around mdbx_canary_put
 
@@ -1982,7 +1986,7 @@ class Env(object):
     def __init__(
         self,
         path: str,
-        flags: MDBXEnvFlags = MDBXEnvFlags.MDBX_ENV_DEFAULTS,
+        flags: int = MDBXEnvFlags.MDBX_ENV_DEFAULTS,
         mode: int = 0o755,
         geometry: Optional[Geometry] = None,
         maxreaders: int = 1,
@@ -1990,11 +1994,11 @@ class Env(object):
         sync_bytes: Optional[int] = None,
         sync_period: Optional[int] = None,
     ):
-        self._env = ctypes.pointer(MDBXEnv())
+        self._env: _Pointer[MDBXEnv] | None = ctypes.pointer(MDBXEnv())
         ret = _lib.mdbx_env_create(ctypes.byref(self._env))
         self._default_db: str | bytes | None = None
         self._current_txn = None
-        self._dependents: List[ReferenceType[TXN] | ReferenceType[DBI]] = []
+        self._dependents: list[ReferenceType[TXN] | ReferenceType[DBI]] = []
         self._ctx: Optional[Any] = None
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
@@ -2030,19 +2034,22 @@ class Env(object):
         if sync_period is not None:
             self.set_option(MDBXOption.MDBX_opt_sync_period, sync_period)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    def __enter__(self):
+    def __enter__(self) -> Env:
         return self
 
-    def __exit__(self, _1, _2, _3):
+    def __exit__(self, exception_type: Optional[Type[BaseException]],
+                 exception_value: Optional[BaseException],
+                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
         self.close()
+        return False
 
-    def __repr__(self):
-        return 'Env { "path" : "%s"}' % self.get_path()
+    def __repr__(self) -> str:
+        return f"Env { "path" : \"{self.get_path()}\" }"
 
-    def __getitem__(self, key: str | bytes):
+    def __getitem__(self, key: str | bytes) -> bytes | None:
         """
         Gets item from currently set default database
         Opens a read only transaction, gets the object, aborts the transaction
@@ -2066,7 +2073,7 @@ class Env(object):
         except Exception as _e:
             return None
 
-    def __setitem__(self, key: str | bytes, val: str | bytes):
+    def __setitem__(self, key: str | bytes, val: str | bytes) -> bytes | None:
         """
         Sets the given key and val in the current default database
         if key or val are strings, they are converted into bytes using utf-8 encoding
@@ -2085,16 +2092,14 @@ class Env(object):
             raise KeyError("Value can only be string or bytes")
         txn = self.start_transaction()
         dbi = txn.open_map(self._default_db)
-        if isinstance(key, str):
-            key = key.encode("utf-8")
-        if isinstance(val, str):
-            val = val.encode("utf-8")
-        val = dbi.put(txn, key, val)
+        key_bytes = key.encode("utf-8") if isinstance(key, str) else key
+        val_bytes: bytes = val.encode("utf-8") if isinstance(val, str) else val
+        result = dbi.put(txn, key_bytes, val_bytes)
         txn.commit()
 
-        return val
+        return result
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[bytes | None, bytes | None]]:
         """
         Create iterator over this Env's currently set default_db
 
@@ -2102,10 +2107,11 @@ class Env(object):
         :rtype: EnvIterator
         """
         txn = self.ro_transaction()
-        cur = Cursor(self._default_db, txn, self._ctx)
+        dbi = txn.open_map(self._default_db)
+        cur = Cursor(dbi, txn, self._ctx)
         return cur.iter()
 
-    def close(self):
+    def close(self) -> None:
         """
         Closes this Env. _In most cases, you don't need to call this._ mdbx-py has
         internal reference counting to _safely_ garbage collect envs, txs and cursors.
@@ -2116,8 +2122,8 @@ class Env(object):
             f"env {self._env} being closed, dependents: {self._dependents}"
         )
         if self._env:
-            for tx in self._dependents:
-                tx = tx()
+            for tx_ref in self._dependents:
+                tx = tx_ref()
                 if tx is not None:
                     tx.close()
             self._dependents = []
@@ -2127,7 +2133,7 @@ class Env(object):
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
 
-    def items(self):
+    def items(self) -> Iterator[tuple[bytes | None, bytes | None]]:
         """
         bsddb compatibility function. Returns an iterator over contents of default db (self._default_db)
         :returns: iterator over self
@@ -2135,7 +2141,7 @@ class Env(object):
         """
         return self.__iter__()
 
-    def get(self, key):
+    def get(self, key: bytes) -> bytes | None:
         """
         Returns the value stored under this key, uses self.__getitem__
         See self.__getitem__ for behaviour
@@ -2143,7 +2149,7 @@ class Env(object):
         """
         return self.__getitem__(key)
 
-    def set_default_db(self, name: str | bytes | None):
+    def set_default_db(self, name: str | bytes | None) -> None:
         """
         Sets the default DB to be used for __setitem__ and __getitem__
         :param name: name of the DBI
@@ -2157,7 +2163,7 @@ class Env(object):
     def rw_transaction(self) -> TXN:
         return self.start_transaction(MDBXTXNFlags.MDBX_TXN_READWRITE, None)
 
-    def start_transaction(self, flags: MDBXTXNFlags = MDBXTXNFlags.MDBX_TXN_READWRITE, parent_txn: Optional[TXN] = None):
+    def start_transaction(self, flags: int = MDBXTXNFlags.MDBX_TXN_READWRITE, parent_txn: Optional[TXN] = None) -> TXN:
         """
         Starts a transaction on the given Env
 
@@ -2174,8 +2180,9 @@ class Env(object):
             txn = TXN(self, parent_txn, flags)
             logging.getLogger(__name__).debug(f"Starting transaction {txn._txn}")
             return txn
+        raise RuntimeError("Env is not available")
 
-    def get_path(self):
+    def get_path(self) -> str:
         """
         Thin wrapper around mdbx_env_get_path
 
@@ -2188,7 +2195,9 @@ class Env(object):
             ret = _lib.mdbx_env_get_path(self._env, ctypes.byref(ptr))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            assert ptr.value
             return ptr.value.decode("utf-8")
+        raise RuntimeError("Env is not available")
 
     def set_user_ctx(self, val: Any) -> None:
         """
@@ -2278,7 +2287,7 @@ class Env(object):
         raise RuntimeError("Env is not available")
 
     def copy(
-        self, destination: str, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS
+        self, destination: str, flags: int = MDBXCopyMode.MDBX_CP_DEFAULTS
     ) -> None:
         """
         Thin wrapper around mdbx_env_copy
@@ -2294,7 +2303,7 @@ class Env(object):
             return
         raise RuntimeError("Env is not available")
 
-    def copy2fd(self, fd: int, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS) -> None:
+    def copy2fd(self, fd: int, flags: int = MDBXCopyMode.MDBX_CP_DEFAULTS) -> None:
         """
         Thin wrapper around mdbx_env_copy2fd
 
@@ -2433,7 +2442,7 @@ class Env(object):
             return val.value
         raise RuntimeError("Env is not available")
 
-    def get_maxkeysize(self, flags: int = 0):
+    def get_maxkeysize(self, flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS) -> Optional[int]:
         """
         Thin wrapper around mdbx_env_get_maxkeysize_ex
 
@@ -2445,7 +2454,7 @@ class Env(object):
             return None if val == -1 else val
         raise RuntimeError("Env is not available")
 
-    def get_maxvalsize(self, flags: int = 0) -> Optional[int]:
+    def get_maxvalsize(self, flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS) -> Optional[int]:
         """
         Thin wrapper around mdbx_env_get_maxvalsize_ex
 
@@ -2476,7 +2485,7 @@ class Env(object):
             return
         raise RuntimeError("Env is not available")
 
-    def get_db_names(self):
+    def get_db_names(self) -> list[str]:
         """
         Returns a list of all databases in the Env
 
@@ -2489,17 +2498,18 @@ class Env(object):
         if self._env:
             if not self.get_maxdbs():
                 return []
-            txn = TXN(self, flags=MDBXTXNFlags.MDBX_TXN_RDONLY)
-            dbi = txn.open_map(flags=0)
-            names = []
+            txn = TXN(self, flags = MDBXTXNFlags.MDBX_TXN_RDONLY)
+            dbi = txn.open_map(flags = MDBXDBFlags.MDBX_DB_DEFAULTS)
+            names: list[str] = []
             cursor = Cursor(dbi, txn)
             for key, val in cursor:
+                assert key
                 names.append(key.decode("utf-8"))
             return names
         raise RuntimeError("Env is not available")
 
     @classmethod
-    def delete(cls, path: str, mode: int = 0):
+    def delete(cls, path: str, mode: MDBXEnvDeleteMode = MDBXEnvDeleteMode.MDBX_ENV_JUST_DELETE) -> bool:
         """
         Thin wrapper around mdbx_env_delete
 
@@ -2519,7 +2529,7 @@ class Env(object):
             raise make_exception(ret)
         return True
 
-    def set_hsr(self, hsr: MDBXHSRFunc):
+    def set_hsr(self, hsr: MDBXHSRFunc) -> None:
         """
         Thin wrapper around mdbx_env_set_hsr
 
@@ -2564,19 +2574,21 @@ class DBI:
         self._dbi = dbi
         self._env = env
 
-    def __del__(self):
+    def __del__(self) -> None:
         pass
 
-    def __enter__(self):
+    def __enter__(self) -> DBI:
         return self
 
-    def __exit__(self, _1, _2, _3):
-        pass
+    def __exit__(self, exception_type: Optional[Type[BaseException]],
+                 exception_value: Optional[BaseException],
+                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
+        return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str("%s: %s" % (self._env, self._dbi))
 
-    def close(self):
+    def close(self) -> None:
         """
         Do nothing and delegate mdbx_env_close to close all handles.
 
@@ -2623,7 +2635,7 @@ class DBI:
             raise make_exception(ret)
         return stats
 
-    def put(self, txn: TXN, key: bytes, value: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT):
+    def put(self, txn: TXN, key: bytes, value: bytes, flags: int = MDBXPutFlags.MDBX_UPSERT) -> bytes | None:
         """
         Thin wrapper around mdbx_put
 
@@ -2649,8 +2661,10 @@ class DBI:
         )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
+        assert value_iov
+        return value_iov.to_bytes()
 
-    def drop(self, txn: TXN, delete: bool = False):
+    def drop(self, txn: TXN, delete: bool = False) -> None:
         """
         Thin wrapper around mdbx_drop
 
@@ -2664,7 +2678,7 @@ class DBI:
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
-    def replace(self, txn: TXN, key: bytes, new_data: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT):
+    def replace(self, txn: TXN, key: bytes, new_data: bytes, flags: int = MDBXPutFlags.MDBX_UPSERT) -> bytes:
         """
         Thin wrapper around mdbx_replace
 
@@ -2699,7 +2713,7 @@ class DBI:
             ]
         )
 
-    def delete(self, txn: TXN, key: bytes, value: Optional[bytes] = None):
+    def delete(self, txn: TXN, key: bytes, value: Optional[bytes] = None) -> None:
         """
         Thin wrapper around mdbx_del
 
@@ -2762,7 +2776,7 @@ class Cursor:
         if txn:
             txn._dependents.append(weakref.ref(self))
 
-    def bind(self, txn: TXN, db: Optional[DBI] = None):
+    def bind(self, txn: TXN, db: Optional[DBI] = None) -> None:
         """
         Thin wrapper around mdbx_cursor_bind
 
@@ -2776,21 +2790,24 @@ class Cursor:
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
-    def __enter__(self):
+    def __enter__(self) -> Cursor:
         return self
 
-    def __exit__(self, _1, _2, _3):
+    def __exit__(self, exception_type: Optional[Type[BaseException]],
+                 exception_value: Optional[BaseException],
+                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
         logging.getLogger(__name__).debug(f"Cursor {self._cursor} exits")
         self.__del__()
+        return False
 
-    def __del__(self):
+    def __del__(self) -> None:
         logging.getLogger(__name__).debug(f"Cursor {self._cursor} being deleted")
         self.close()
 
-    def __iter__(self):
+    def __iter__(self) -> Cursor:
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple[bytes | None, bytes | None]:
         """
         Wrapper around mdbx_cursor_get and mdbx_Cursor_eof
 
@@ -2798,21 +2815,21 @@ class Cursor:
         Raises StopIteration if the cursor can not be moved further (last item returned was the last item stored under this key)
         """
         if self._cursor:
-            val = Iovec(bytes())
-            key = Iovec(bytes())
+            val_iov = Iovec(bytes())
+            key_iov = Iovec(bytes())
             if not self._started:
                 self._started = True
                 ret = _lib.mdbx_cursor_get(
                     self._cursor,
-                    ctypes.pointer(key),
-                    ctypes.pointer(val),
+                    ctypes.pointer(key_iov),
+                    ctypes.pointer(val_iov),
                     MDBXCursorOp.MDBX_FIRST,
                 )
             else:
                 ret = _lib.mdbx_cursor_get(
                     self._cursor,
-                    ctypes.pointer(key),
-                    ctypes.pointer(val),
+                    ctypes.pointer(key_iov),
+                    ctypes.pointer(val_iov),
                     MDBXCursorOp.MDBX_NEXT,
                 )
 
@@ -2821,15 +2838,15 @@ class Cursor:
                     raise StopIteration
                 raise make_exception(ret)
             val = bytes(
-                ctypes.cast(val.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: val.iov_len]
+                ctypes.cast(val_iov.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: val_iov.iov_len]
             )
             key = bytes(
-                ctypes.cast(key.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: key.iov_len]
+                ctypes.cast(key_iov.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: key_iov.iov_len]
             )
             return key, val
         return None, None
 
-    def close(self):
+    def close(self) -> None:
         """
         Thin wrapper around mdbx_cursor_close
 
@@ -2856,7 +2873,7 @@ class Cursor:
         """
         return self._ctx
 
-    def set_user_ctx_int(self, ptr: ctypes.c_void_p):
+    def set_user_ctx_int(self, ptr: ctypes.c_void_p) -> None:
         """
         Thin wrapper around mdbx_cursor_set_userctx
 
@@ -2920,14 +2937,14 @@ class Cursor:
         self.copy(cursor)
         return cursor
 
-    def first(self) -> Tuple[Optional[bytes], Optional[bytes]]:
+    def first(self) -> tuple[Optional[bytes], Optional[bytes]]:
         return self.get_full(None, MDBXCursorOp.MDBX_FIRST)
 
     def first_dup(self) -> Optional[bytes]:
         _, v = self.get_full(None, MDBXCursorOp.MDBX_FIRST_DUP)
         return v
 
-    def last(self) -> Tuple[Optional[bytes], Optional[bytes]]:
+    def last(self) -> tuple[Optional[bytes], Optional[bytes]]:
         return self.get_full(None, MDBXCursorOp.MDBX_LAST)
 
     def last_dup(self) -> Optional[bytes]:
@@ -2936,7 +2953,7 @@ class Cursor:
 
     def get_full(
         self, key: Optional[bytes], cursor_op: MDBXCursorOp
-    ) -> Tuple[Optional[bytes], Optional[bytes]]:
+    ) -> tuple[Optional[bytes], Optional[bytes]]:
         if self._cursor:
             io_key = Iovec(key)
             io_data = Iovec(None, 1)
@@ -2971,7 +2988,7 @@ class Cursor:
         return v
 
     def put(
-        self, key: bytes, val: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT
+        self, key: bytes, val: bytes, flags: int = MDBXPutFlags.MDBX_UPSERT
     ) -> None:
         """
         Thin wrapper around mdbx_cursor_put
@@ -3082,7 +3099,7 @@ class Cursor:
                 raise make_exception(ret)
         raise RuntimeError("Cursor is not available")
 
-    def renew(self, txn: TXN):
+    def renew(self, txn: TXN) -> bool:
         """
         Thin wrapper around mdbx_cursor_renew
 
@@ -3103,7 +3120,7 @@ class Cursor:
         start_key: Optional[bytes] = None,
         from_next: bool = False,
         copy_cursor: bool = False,
-    ) -> Iterator[Tuple[bytes, bytes]]:
+    ) -> Iterator[tuple[bytes | None, bytes | None]]:
         if start_key is not None and from_next:
             raise RuntimeError(
                 "start_key and from_next can not be used at the same time"
@@ -3127,7 +3144,7 @@ class Cursor:
         start_key: Optional[bytes] = None,
         from_next: bool = False,
         copy_cursor: bool = False,
-    ) -> Iterator[Tuple[bytes, bytes]]:
+    ) -> Iterator[tuple[bytes | None, bytes | None]]:
         its = self.iter_dupsort_rows(start_key, from_next, copy_cursor)
         return itertools.chain.from_iterable(its)
 
@@ -3136,7 +3153,7 @@ class Cursor:
         start_key: Optional[bytes] = None,
         from_next: bool = False,
         copy_cursor: bool = False,
-    ) -> Iterator[Iterator[Tuple[bytes, bytes]]]:
+    ) -> Iterator[Iterator[tuple[bytes | None, bytes | None]]]:
         if start_key is not None and from_next:
             raise RuntimeError(
                 "start_key and from_next can not be used at the same time"
@@ -3167,10 +3184,10 @@ class DBIter(object):
 
         self.op = first_op
 
-    def __iter__(self):
+    def __iter__(self) -> DBIter:
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple[bytes | None, bytes | None]:
         op = self.first_op
         if self.second_op is not None:
             self.first_op = self.second_op
@@ -3187,10 +3204,10 @@ class DBDupIter(object):
         self.cur = cur
         self.op = op
 
-    def __iter__(self):
+    def __iter__(self) -> DBDupIter:
         return self
 
-    def __next__(self):
+    def __next__(self) -> DBIter:
         op = self.op
         self.op = MDBXCursorOp.MDBX_NEXT_NODUP
 
@@ -3203,7 +3220,7 @@ class DBDupIter(object):
         )
 
 
-def get_build_info():
+def get_build_info() -> Any:
     """
     :returns mdbx_build struct embedded in lib
     :rtype MDBXBuildInfo
@@ -3211,7 +3228,7 @@ def get_build_info():
     return MDBXBuildInfo.in_dll(_lib, "mdbx_build")
 
 
-def get_version_info():
+def get_version_info() -> Any:
     """
     :returns mdbx_version struct embedded in lib
     :rtype MDBXVersionInfo
@@ -3219,7 +3236,7 @@ def get_version_info():
     return MDBXVersionInfo.in_dll(_lib, "mdbx_version")
 
 
-def make_exception(errno: int):
+def make_exception(errno: int) -> BaseException:
     """
     Construct an exception as correct
     """

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import sys
 import itertools
 from typing import Optional, Tuple, Iterator, List, Any
+from _ctypes import _Pointer
 from weakref import ReferenceType
 import weakref
 import logging
@@ -1623,7 +1624,7 @@ class TXN:
         :param context: User defined context object, can be anything.
         :type context: Object
         """
-        self._txn = ctypes.POINTER(MDBXTXN)()
+        self._txn: _Pointer[MDBXTXN] | None = ctypes.POINTER(MDBXTXN)()
         self._env: Env | None = env
         self._ctx: Optional[Any] = ctx
         self._flags = flags

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2875,7 +2875,7 @@ class Cursor:
         if self._cursor:
             return _lib.mdbx_cursor_dbi(self._cursor)
 
-    def copy(self, dest: Cursor):
+    def copy(self, dest: Cursor) -> Cursor:
         """
         Thin wrapper around mdbx_cursor_copy
         Copies this cursor's state to the given Cursor
@@ -2888,6 +2888,8 @@ class Cursor:
             ret = _lib.mdbx_cursor_copy(self._cursor, dest._cursor)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return dest
+        raise RuntimeError("Cursor is not available")
 
     def dup(self) -> Cursor:
         cursor = Cursor(self._db, self._txn, self._ctx)

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -3185,7 +3185,7 @@ def make_exception(errno: int):
     Construct an exception as correct
     """
     err = _lib.mdbx_liberr2str(errno)
-    if err != None:
+    if err is not None:
         return MDBXErrorExc(errno, err)
     return OSError(errno, os.strerror(errno))
 

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1014,16 +1014,6 @@ class MDBXError(enum.IntFlag):
     MDBX_EREMOTE = 15  # Win32 doesn't have this
 
 
-class MDBXMode(enum.IntEnum):
-
-    def from_param(self):
-        return int(self)
-
-    readonly = 0
-    write_file_io = 1
-    write_mapped_io = 2
-
-
 class MDBXOption(enum.IntEnum):
 
     def from_param(self):
@@ -1979,7 +1969,7 @@ class Env(object):
     :param flags: Combination of MDBXEnvFlags
     :type flags: MDBXEnvFlags
     :param mode: Access mode for the environment directory
-    :type mode: MDBXMode
+    :type mode: int
     :param geometry: Geometry of the database, entirely optional
     :type geometry: Geometry
     :param maxreaders: Maxreaders to be set, defaults to 1
@@ -1993,7 +1983,7 @@ class Env(object):
         self,
         path: str,
         flags: MDBXEnvFlags = MDBXEnvFlags.MDBX_ENV_DEFAULTS,
-        mode: MDBXMode = 0o755,
+        mode: int = 0o755,
         geometry: Optional[Geometry] = None,
         maxreaders: int = 1,
         maxdbs: int = 1,

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2718,7 +2718,6 @@ class DBI:
         :param value: The value to delete
         :type value: bytes
         """
-        old_data = Iovec()
         key_iovec = Iovec(key)
         ret = _lib.mdbx_del(
             txn._txn,

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -644,7 +644,6 @@ class MDBXEnvFlags(enum.IntFlag):
 
 
 class MDBXTXNFlags(enum.IntFlag):
-
     # Start read-write transaction.
     #
     # Only one write transaction may be active at a time. Writes are fully
@@ -684,7 +683,6 @@ class MDBXTXNFlags(enum.IntFlag):
 
 
 class MDBXDBFlags(enum.IntFlag):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -729,7 +727,6 @@ class MDBXDBFlags(enum.IntFlag):
 
 
 class MDBXPutFlags(enum.IntFlag):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -790,7 +787,6 @@ class MDBXCopyFlags(enum.IntFlag):
 
 
 class MDBXCursorOp(enum.IntEnum):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -1016,7 +1012,6 @@ class MDBXError(enum.IntFlag):
 
 
 class MDBXOption(enum.IntEnum):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -1035,7 +1030,6 @@ class MDBXOption(enum.IntEnum):
 
 
 class MDBXEnvDeleteMode(enum.IntEnum):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -1052,7 +1046,6 @@ class MDBXDBIState(enum.IntFlag):
 
 
 class MDBXPageType(enum.IntEnum):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -1068,7 +1061,6 @@ class MDBXPageType(enum.IntEnum):
 
 
 class MDBXCopyMode(enum.IntEnum):
-
     def from_param(self) -> int:
         return int(self)
 
@@ -1601,7 +1593,11 @@ class TXN:
     """
 
     def __init__(
-        self, env: Env, parent: Optional[TXN] = None, flags: int = MDBXTXNFlags.MDBX_TXN_READWRITE, ctx: Optional[Any] = None
+        self,
+        env: Env,
+        parent: Optional[TXN] = None,
+        flags: int = MDBXTXNFlags.MDBX_TXN_READWRITE,
+        ctx: Optional[Any] = None,
     ):
         """
 
@@ -1636,9 +1632,12 @@ class TXN:
     def __enter__(self) -> TXN:
         return self
 
-    def __exit__(self, exception_type: Optional[Type[BaseException]],
-                 exception_value: Optional[BaseException],
-                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
+    def __exit__(
+        self,
+        exception_type: Optional[Type[BaseException]],
+        exception_value: Optional[BaseException],
+        exception_traceback: Optional[TracebackType],
+    ) -> Literal[False]:
         logging.getLogger(__name__).debug(
             f"Transaction {self._txn} exits, dependents: {self._dependents}"
         )
@@ -2040,14 +2039,17 @@ class Env(object):
     def __enter__(self) -> Env:
         return self
 
-    def __exit__(self, exception_type: Optional[Type[BaseException]],
-                 exception_value: Optional[BaseException],
-                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
+    def __exit__(
+        self,
+        exception_type: Optional[Type[BaseException]],
+        exception_value: Optional[BaseException],
+        exception_traceback: Optional[TracebackType],
+    ) -> Literal[False]:
         self.close()
         return False
 
     def __repr__(self) -> str:
-        return f"Env { "path" : \"{self.get_path()}\" }"
+        return f'Env {{ "path" : "{self.get_path()}" }}'
 
     def __getitem__(self, key: str | bytes) -> bytes | None:
         """
@@ -2163,7 +2165,11 @@ class Env(object):
     def rw_transaction(self) -> TXN:
         return self.start_transaction(MDBXTXNFlags.MDBX_TXN_READWRITE, None)
 
-    def start_transaction(self, flags: int = MDBXTXNFlags.MDBX_TXN_READWRITE, parent_txn: Optional[TXN] = None) -> TXN:
+    def start_transaction(
+        self,
+        flags: int = MDBXTXNFlags.MDBX_TXN_READWRITE,
+        parent_txn: Optional[TXN] = None,
+    ) -> TXN:
         """
         Starts a transaction on the given Env
 
@@ -2442,7 +2448,9 @@ class Env(object):
             return val.value
         raise RuntimeError("Env is not available")
 
-    def get_maxkeysize(self, flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS) -> Optional[int]:
+    def get_maxkeysize(
+        self, flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS
+    ) -> Optional[int]:
         """
         Thin wrapper around mdbx_env_get_maxkeysize_ex
 
@@ -2454,7 +2462,9 @@ class Env(object):
             return None if val == -1 else val
         raise RuntimeError("Env is not available")
 
-    def get_maxvalsize(self, flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS) -> Optional[int]:
+    def get_maxvalsize(
+        self, flags: int = MDBXDBFlags.MDBX_DB_DEFAULTS
+    ) -> Optional[int]:
         """
         Thin wrapper around mdbx_env_get_maxvalsize_ex
 
@@ -2498,8 +2508,8 @@ class Env(object):
         if self._env:
             if not self.get_maxdbs():
                 return []
-            txn = TXN(self, flags = MDBXTXNFlags.MDBX_TXN_RDONLY)
-            dbi = txn.open_map(flags = MDBXDBFlags.MDBX_DB_DEFAULTS)
+            txn = TXN(self, flags=MDBXTXNFlags.MDBX_TXN_RDONLY)
+            dbi = txn.open_map(flags=MDBXDBFlags.MDBX_DB_DEFAULTS)
             names: list[str] = []
             cursor = Cursor(dbi, txn)
             for key, val in cursor:
@@ -2509,7 +2519,9 @@ class Env(object):
         raise RuntimeError("Env is not available")
 
     @classmethod
-    def delete(cls, path: str, mode: MDBXEnvDeleteMode = MDBXEnvDeleteMode.MDBX_ENV_JUST_DELETE) -> bool:
+    def delete(
+        cls, path: str, mode: MDBXEnvDeleteMode = MDBXEnvDeleteMode.MDBX_ENV_JUST_DELETE
+    ) -> bool:
         """
         Thin wrapper around mdbx_env_delete
 
@@ -2580,9 +2592,12 @@ class DBI:
     def __enter__(self) -> DBI:
         return self
 
-    def __exit__(self, exception_type: Optional[Type[BaseException]],
-                 exception_value: Optional[BaseException],
-                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
+    def __exit__(
+        self,
+        exception_type: Optional[Type[BaseException]],
+        exception_value: Optional[BaseException],
+        exception_traceback: Optional[TracebackType],
+    ) -> Literal[False]:
         return False
 
     def __repr__(self) -> str:
@@ -2611,7 +2626,9 @@ class DBI:
         """
         key_iovec = Iovec(key)
         data_iovec = Iovec(None, 1)
-        ret = _lib.mdbx_get(txn._txn, self._dbi, ctypes.byref(key_iovec), ctypes.byref(data_iovec))
+        ret = _lib.mdbx_get(
+            txn._txn, self._dbi, ctypes.byref(key_iovec), ctypes.byref(data_iovec)
+        )
         if ret == MDBXError.MDBX_NOTFOUND:
             return None
         if ret != MDBXError.MDBX_SUCCESS.value:
@@ -2635,7 +2652,9 @@ class DBI:
             raise make_exception(ret)
         return stats
 
-    def put(self, txn: TXN, key: bytes, value: bytes, flags: int = MDBXPutFlags.MDBX_UPSERT) -> bytes | None:
+    def put(
+        self, txn: TXN, key: bytes, value: bytes, flags: int = MDBXPutFlags.MDBX_UPSERT
+    ) -> bytes | None:
         """
         Thin wrapper around mdbx_put
 
@@ -2678,7 +2697,13 @@ class DBI:
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
-    def replace(self, txn: TXN, key: bytes, new_data: bytes, flags: int = MDBXPutFlags.MDBX_UPSERT) -> bytes:
+    def replace(
+        self,
+        txn: TXN,
+        key: bytes,
+        new_data: bytes,
+        flags: int = MDBXPutFlags.MDBX_UPSERT,
+    ) -> bytes:
         """
         Thin wrapper around mdbx_replace
 
@@ -2743,7 +2768,12 @@ class Cursor:
     Used for iterating over values within a key
     """
 
-    def __init__(self, db: Optional[DBI] = None, txn: Optional[TXN] = None, ctx: Optional[Any] = None):
+    def __init__(
+        self,
+        db: Optional[DBI] = None,
+        txn: Optional[TXN] = None,
+        ctx: Optional[Any] = None,
+    ):
         """
         Thin wrapper around either mdbx_cursor_open or mdbx_cursor_create
 
@@ -2793,9 +2823,12 @@ class Cursor:
     def __enter__(self) -> Cursor:
         return self
 
-    def __exit__(self, exception_type: Optional[Type[BaseException]],
-                 exception_value: Optional[BaseException],
-                 exception_traceback: Optional[TracebackType]) -> Literal[False]:
+    def __exit__(
+        self,
+        exception_type: Optional[Type[BaseException]],
+        exception_value: Optional[BaseException],
+        exception_traceback: Optional[TracebackType],
+    ) -> Literal[False]:
         logging.getLogger(__name__).debug(f"Cursor {self._cursor} exits")
         self.__del__()
         return False
@@ -2838,10 +2871,14 @@ class Cursor:
                     raise StopIteration
                 raise make_exception(ret)
             val = bytes(
-                ctypes.cast(val_iov.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: val_iov.iov_len]
+                ctypes.cast(val_iov.iov_base, ctypes.POINTER(ctypes.c_ubyte))[
+                    : val_iov.iov_len
+                ]
             )
             key = bytes(
-                ctypes.cast(key_iov.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: key_iov.iov_len]
+                ctypes.cast(key_iov.iov_base, ctypes.POINTER(ctypes.c_ubyte))[
+                    : key_iov.iov_len
+                ]
             )
             return key, val
         return None, None
@@ -3174,7 +3211,6 @@ class Cursor:
 
 
 class DBIter(object):
-
     def __init__(
         self, cur: Cursor, first_op: MDBXCursorOp, second_op: Optional[MDBXCursorOp]
     ):
@@ -3199,7 +3235,6 @@ class DBIter(object):
 
 
 class DBDupIter(object):
-
     def __init__(self, cur: Cursor, op: MDBXCursorOp):
         self.cur = cur
         self.op = op

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2597,7 +2597,7 @@ class DBI:
             raise make_exception(ret)
         return stats
 
-    def put(self, txn: TXN, key: bytes, value: bytes, flags: MDBXPutFlags = 0):
+    def put(self, txn: TXN, key: bytes, value: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT):
         """
         Thin wrapper around mdbx_put
 
@@ -2638,7 +2638,7 @@ class DBI:
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
-    def replace(self, txn: TXN, key: bytes, new_data: bytes, flags: MDBXPutFlags = 0):
+    def replace(self, txn: TXN, key: bytes, new_data: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT):
         """
         Thin wrapper around mdbx_replace
 
@@ -3400,10 +3400,10 @@ _lib.mdbx_cursor_put.argtypes = [
     ctypes.POINTER(MDBXCursor),
     ctypes.POINTER(Iovec),
     ctypes.POINTER(Iovec),
-    MDBXPutFlags,
+    ctypes.c_uint,
 ]
 _lib.mdbx_cursor_put.restype = ctypes.c_int
-_lib.mdbx_cursor_del.argtypes = [ctypes.POINTER(MDBXCursor), MDBXPutFlags]
+_lib.mdbx_cursor_del.argtypes = [ctypes.POINTER(MDBXCursor), ctypes.c_uint]
 _lib.mdbx_cursor_del.restype = ctypes.c_int
 _lib.mdbx_cursor_count.argtypes = [
     ctypes.POINTER(MDBXCursor),
@@ -3426,7 +3426,7 @@ try:
         ctypes.POINTER(Iovec),
         ctypes.POINTER(Iovec),
         MDBXAttr,
-        MDBXPutFlags,
+        ctypes.c_uint,
     ]
     _lib.mdbx_cursor_put_attr.restype = ctypes.c_int
 except:
@@ -3439,7 +3439,7 @@ try:
         ctypes.POINTER(Iovec),
         ctypes.POINTER(Iovec),
         MDBXAttr,
-        MDBXPutFlags,
+        ctypes.c_uint,
     ]
     _lib.mdbx_put_attr.restype = ctypes.c_int
 except:

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -174,7 +174,7 @@ class MDBXConstants(enum.IntFlag):
     MDBX_MAX_DBI = 32765
 
     # The maximum size of a data item.
-    MDBX_MAXDATASIZE = 0x7fff0000
+    MDBX_MAXDATASIZE = 0x7FFF0000
 
     # The minimal database page size in bytes.
     MDBX_MIN_PAGESIZE = 256
@@ -770,6 +770,7 @@ class MDBXPutFlags(enum.IntFlag):
     # Store multiple data items in one call.
     MDBX_MULTIPLE = 0x80000
 
+
 # \brief Environment copy flags
 # \ingroup c_extra
 # \see mdbx_env_copy() \see mdbx_env_copy2fd()
@@ -1102,20 +1103,25 @@ class MDBXBuildInfo(ctypes.Structure):
         const char *flags;    /**< CFLAGS and CXXFLAGS */
     }
     """
-    _fields_ = [("datetime", ctypes.c_char_p),
-                ("target", ctypes.c_char_p),
-                ("options", ctypes.c_char_p),
-                ("compiler", ctypes.c_char_p),
-                ("flags", ctypes.c_char_p)]
+
+    _fields_ = [
+        ("datetime", ctypes.c_char_p),
+        ("target", ctypes.c_char_p),
+        ("options", ctypes.c_char_p),
+        ("compiler", ctypes.c_char_p),
+        ("flags", ctypes.c_char_p),
+    ]
 
     def __repr__(self):
-        return str({
-            "datetime": self.datetime,
-            "target": self.target,
-            "options": self.options,
-            "compiler": self.compiler,
-            "flags": self.flags
-        })
+        return str(
+            {
+                "datetime": self.datetime,
+                "target": self.target,
+                "options": self.options,
+                "compiler": self.compiler,
+                "flags": self.flags,
+            }
+        )
 
 
 class MDBXVersionInfo(ctypes.Structure):
@@ -1135,28 +1141,33 @@ class MDBXVersionInfo(ctypes.Structure):
         const char *sourcery;   /**< sourcery anchor for pinning */
     }
     """
-    _fields_ = [("major", ctypes.c_uint8),
-                ("minor", ctypes.c_uint8),
-                ("release", ctypes.c_uint16),
-                ("revision", ctypes.c_uint32),
-                ("datetime", ctypes.c_char_p),
-                ("tree", ctypes.c_char_p),
-                ("commit", ctypes.c_char_p),
-                ("describe", ctypes.c_char_p),
-                ("sourcery", ctypes.c_char_p)]
+
+    _fields_ = [
+        ("major", ctypes.c_uint8),
+        ("minor", ctypes.c_uint8),
+        ("release", ctypes.c_uint16),
+        ("revision", ctypes.c_uint32),
+        ("datetime", ctypes.c_char_p),
+        ("tree", ctypes.c_char_p),
+        ("commit", ctypes.c_char_p),
+        ("describe", ctypes.c_char_p),
+        ("sourcery", ctypes.c_char_p),
+    ]
 
     def __repr__(self):
-        return str({
-            "major": self.major,
-            "minor": self.minor,
-            "release": self.release,
-            "revision": self.revision,
-            "datetime": self.datetime,
-            "tree": self.tree,
-            "commit": self.commit,
-            "describe": self.describe,
-            "sourcery": self.sourcery
-        })
+        return str(
+            {
+                "major": self.major,
+                "minor": self.minor,
+                "release": self.release,
+                "revision": self.revision,
+                "datetime": self.datetime,
+                "tree": self.tree,
+                "commit": self.commit,
+                "describe": self.describe,
+                "sourcery": self.sourcery,
+            }
+        )
 
 
 class MDBXStat(ctypes.Structure):
@@ -1174,23 +1185,29 @@ class MDBXStat(ctypes.Structure):
       uint64_t ms_mod_txnid; /**< Transaction ID of committed last modification */
     };
     """
-    _fields_ = [("ms_psize", ctypes.c_uint32),
-                ("ms_depth", ctypes.c_uint32),
-                ("ms_branch_pages", ctypes.c_uint64),
-                ("ms_leaf_pages", ctypes.c_uint64),
-                ("ms_overflow_pages", ctypes.c_uint64),
-                ("ms_entries", ctypes.c_uint64),
-                ("ms_mod_txnid", ctypes.c_uint64)]
+
+    _fields_ = [
+        ("ms_psize", ctypes.c_uint32),
+        ("ms_depth", ctypes.c_uint32),
+        ("ms_branch_pages", ctypes.c_uint64),
+        ("ms_leaf_pages", ctypes.c_uint64),
+        ("ms_overflow_pages", ctypes.c_uint64),
+        ("ms_entries", ctypes.c_uint64),
+        ("ms_mod_txnid", ctypes.c_uint64),
+    ]
 
     def __repr__(self):
-        return str({"ms_psize": self.ms_psize,
-                    "ms_depth": self.ms_depth,
-                    "ms_branch_pages": self.ms_branch_pages,
-                    "ms_leaf_pages": self.ms_leaf_pages,
-                    "ms_overflow_pages": self.ms_overflow_pages,
-                    "ms_entries": self.ms_entries,
-                    "ms_mod_txnid": self.ms_mod_txnid
-                    })
+        return str(
+            {
+                "ms_psize": self.ms_psize,
+                "ms_depth": self.ms_depth,
+                "ms_branch_pages": self.ms_branch_pages,
+                "ms_leaf_pages": self.ms_leaf_pages,
+                "ms_overflow_pages": self.ms_overflow_pages,
+                "ms_entries": self.ms_entries,
+                "ms_mod_txnid": self.ms_mod_txnid,
+            }
+        )
 
 
 class MDBXMiGeo(ctypes.Structure):
@@ -1205,78 +1222,72 @@ class MDBXMiGeo(ctypes.Structure):
         uint64_t grow;    /**< Growth step for datafile */
       } mi_geo;
     """
-    _fields_ = [("lower", ctypes.c_uint64),
-                ("upper", ctypes.c_uint64),
-                ("current", ctypes.c_uint64),
-                ("shrink", ctypes.c_uint64),
-                ("grow", ctypes.c_uint64)]
+
+    _fields_ = [
+        ("lower", ctypes.c_uint64),
+        ("upper", ctypes.c_uint64),
+        ("current", ctypes.c_uint64),
+        ("shrink", ctypes.c_uint64),
+        ("grow", ctypes.c_uint64),
+    ]
 
     def __repr__(self):
-        return str({"lower": self.lower,
-                    "upper": self.upper,
-                    "current": self.current,
-                    "shrink": self.shrink,
-                    "grow": self.grow
-                    })
+        return str(
+            {
+                "lower": self.lower,
+                "upper": self.upper,
+                "current": self.current,
+                "shrink": self.shrink,
+                "grow": self.grow,
+            }
+        )
 
 
 class MDBXEnvinfoCurrent(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_uint64),
-                ("y", ctypes.c_uint64)]
+    _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
     def __repr__(self):
-        return str({
-            "x": self.x,
-            "y": self.y
-        })
+        return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfoMeta0(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_uint64),
-                ("y", ctypes.c_uint64)]
+    _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
     def __repr__(self):
-        return str({
-            "x": self.x,
-            "y": self.y
-        })
+        return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfoMeta1(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_uint64),
-                ("y", ctypes.c_uint64)]
+    _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
     def __repr__(self):
-        return str({
-            "x": self.x,
-            "y": self.y
-        })
+        return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfoMeta2(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_uint64),
-                ("y", ctypes.c_uint64)]
+    _fields_ = [("x", ctypes.c_uint64), ("y", ctypes.c_uint64)]
 
     def __repr__(self):
-        return str({
-            "x": self.x,
-            "y": self.y
-        })
+        return str({"x": self.x, "y": self.y})
 
 
 class MDBXEnvinfo_mi_bootid(ctypes.Structure):
-    _fields_ = [("current", MDBXEnvinfoCurrent),
-                ("meta0", MDBXEnvinfoMeta0),
-                ("meta1", MDBXEnvinfoMeta1),
-                ("meta2", MDBXEnvinfoMeta2)]
+    _fields_ = [
+        ("current", MDBXEnvinfoCurrent),
+        ("meta0", MDBXEnvinfoMeta0),
+        ("meta1", MDBXEnvinfoMeta1),
+        ("meta2", MDBXEnvinfoMeta2),
+    ]
 
     def __repr__(self):
-        return str({
-            "current": self.current,
-            "meta0": self.meta0,
-            "meta1": self.meta1,
-            "meta2": self.meta2
-        })
+        return str(
+            {
+                "current": self.current,
+                "meta0": self.meta0,
+                "meta1": self.meta1,
+                "meta2": self.meta2,
+            }
+        )
 
 
 class MDBXEnvinfo(ctypes.Structure):
@@ -1356,56 +1367,61 @@ class MDBXEnvinfo(ctypes.Structure):
     };
 
     """
-    _fields_ = [("MDBXMiGeo", MDBXMiGeo),
-                ("mi_mapsize", ctypes.c_uint64),
-                ("mi_last_pgno", ctypes.c_uint64),
-                ("mi_recent_txnid", ctypes.c_uint64),
-                ("mi_latter_reader_txnid", ctypes.c_uint64),
-                ("mi_self_latter_reader_txnid", ctypes.c_uint64),
-                ("mi_meta0_txnid", ctypes.c_uint64),
-                ("mi_meta0_sign", ctypes.c_uint64),
-                ("mi_meta1_txnid", ctypes.c_uint64),
-                ("mi_meta1_sign", ctypes.c_uint64),
-                ("mi_meta2_txnid", ctypes.c_uint64),
-                ("mi_meta2_sign", ctypes.c_uint64),
-                ("mi_maxreaders", ctypes.c_uint32),
-                ("mi_numreaders", ctypes.c_uint32),
-                ("mi_dxb_pagesize", ctypes.c_uint32),
-                ("mi_sys_pagesize", ctypes.c_uint32),
-                ("mi_bootid", MDBXEnvinfo_mi_bootid),
-                ("mi_unsync_volume", ctypes.c_uint64),
-                ("mi_autosync_threshold", ctypes.c_uint64),
-                ("mi_since_sync_seconds16dot16", ctypes.c_uint32),
-                ("mi_autosync_period_seconds16dot16", ctypes.c_uint32),
-                ("mi_since_reader_check_seconds16dot16", ctypes.c_uint32),
-                ("mi_mode", ctypes.c_uint32)]
+
+    _fields_ = [
+        ("MDBXMiGeo", MDBXMiGeo),
+        ("mi_mapsize", ctypes.c_uint64),
+        ("mi_last_pgno", ctypes.c_uint64),
+        ("mi_recent_txnid", ctypes.c_uint64),
+        ("mi_latter_reader_txnid", ctypes.c_uint64),
+        ("mi_self_latter_reader_txnid", ctypes.c_uint64),
+        ("mi_meta0_txnid", ctypes.c_uint64),
+        ("mi_meta0_sign", ctypes.c_uint64),
+        ("mi_meta1_txnid", ctypes.c_uint64),
+        ("mi_meta1_sign", ctypes.c_uint64),
+        ("mi_meta2_txnid", ctypes.c_uint64),
+        ("mi_meta2_sign", ctypes.c_uint64),
+        ("mi_maxreaders", ctypes.c_uint32),
+        ("mi_numreaders", ctypes.c_uint32),
+        ("mi_dxb_pagesize", ctypes.c_uint32),
+        ("mi_sys_pagesize", ctypes.c_uint32),
+        ("mi_bootid", MDBXEnvinfo_mi_bootid),
+        ("mi_unsync_volume", ctypes.c_uint64),
+        ("mi_autosync_threshold", ctypes.c_uint64),
+        ("mi_since_sync_seconds16dot16", ctypes.c_uint32),
+        ("mi_autosync_period_seconds16dot16", ctypes.c_uint32),
+        ("mi_since_reader_check_seconds16dot16", ctypes.c_uint32),
+        ("mi_mode", ctypes.c_uint32),
+    ]
 
     def __repr__(self):
-        return str({
-            "MDBXMiGeo": self.MDBXMiGeo,
-            "mi_mapsize": self.mi_mapsize,
-            "mi_last_pgno": self.mi_last_pgno,
-            "mi_recent_txnid": self.mi_recent_txnid,
-            "mi_latter_reader_txnid": self.mi_latter_reader_txnid,
-            "mi_self_latter_reader_txnid": self.mi_self_latter_reader_txnid,
-            "mi_meta0_txnid": self.mi_meta0_txnid,
-            "mi_meta0_sign": self.mi_meta0_sign,
-            "mi_meta1_txnid": self.mi_meta1_txnid,
-            "mi_meta1_sign": self.mi_meta1_sign,
-            "mi_meta2_txnid": self.mi_meta2_txnid,
-            "mi_meta2_sign": self.mi_meta2_sign,
-            "mi_maxreaders": self.mi_maxreaders,
-            "mi_numreaders": self.mi_numreaders,
-            "mi_dxb_pagesize": self.mi_dxb_pagesize,
-            "mi_sys_pagesize": self.mi_sys_pagesize,
-            "mi_bootid": self.mi_bootid,
-            "mi_unsync_volume": self.mi_unsync_volume,
-            "mi_autosync_threshold": self.mi_autosync_threshold,
-            "mi_since_sync_seconds16dot16": self.mi_since_sync_seconds16dot16,
-            "mi_autosync_period_seconds16dot16": self.mi_autosync_period_seconds16dot16,
-            "mi_since_reader_check_seconds16dot16": self.mi_since_reader_check_seconds16dot16,
-            "mi_mode": self.mi_mode,
-        })
+        return str(
+            {
+                "MDBXMiGeo": self.MDBXMiGeo,
+                "mi_mapsize": self.mi_mapsize,
+                "mi_last_pgno": self.mi_last_pgno,
+                "mi_recent_txnid": self.mi_recent_txnid,
+                "mi_latter_reader_txnid": self.mi_latter_reader_txnid,
+                "mi_self_latter_reader_txnid": self.mi_self_latter_reader_txnid,
+                "mi_meta0_txnid": self.mi_meta0_txnid,
+                "mi_meta0_sign": self.mi_meta0_sign,
+                "mi_meta1_txnid": self.mi_meta1_txnid,
+                "mi_meta1_sign": self.mi_meta1_sign,
+                "mi_meta2_txnid": self.mi_meta2_txnid,
+                "mi_meta2_sign": self.mi_meta2_sign,
+                "mi_maxreaders": self.mi_maxreaders,
+                "mi_numreaders": self.mi_numreaders,
+                "mi_dxb_pagesize": self.mi_dxb_pagesize,
+                "mi_sys_pagesize": self.mi_sys_pagesize,
+                "mi_bootid": self.mi_bootid,
+                "mi_unsync_volume": self.mi_unsync_volume,
+                "mi_autosync_threshold": self.mi_autosync_threshold,
+                "mi_since_sync_seconds16dot16": self.mi_since_sync_seconds16dot16,
+                "mi_autosync_period_seconds16dot16": self.mi_autosync_period_seconds16dot16,
+                "mi_since_reader_check_seconds16dot16": self.mi_since_reader_check_seconds16dot16,
+                "mi_mode": self.mi_mode,
+            }
+        )
 
 
 class MDBXCommitLatency(ctypes.Structure):
@@ -1431,24 +1447,29 @@ class MDBXCommitLatency(ctypes.Structure):
       uint32_t whole;
     };
     """
-    _fields_ = [("preparation", ctypes.c_uint32),
-                ("gc", ctypes.c_uint32),
-                ("audit", ctypes.c_uint32),
-                ("write", ctypes.c_uint32),
-                ("sync", ctypes.c_uint32),
-                ("ending", ctypes.c_uint32),
-                ("whole", ctypes.c_uint32)]
+
+    _fields_ = [
+        ("preparation", ctypes.c_uint32),
+        ("gc", ctypes.c_uint32),
+        ("audit", ctypes.c_uint32),
+        ("write", ctypes.c_uint32),
+        ("sync", ctypes.c_uint32),
+        ("ending", ctypes.c_uint32),
+        ("whole", ctypes.c_uint32),
+    ]
 
     def __repr__(self):
-        return str({
-            "preparation": self.preparation,
-            "gc": self.gc,
-            "audit": self.audit,
-            "write": self.write,
-            "sync": self.sync,
-            "ending": self.ending,
-            "whole": self.whole
-        })
+        return str(
+            {
+                "preparation": self.preparation,
+                "gc": self.gc,
+                "audit": self.audit,
+                "write": self.write,
+                "sync": self.sync,
+                "ending": self.ending,
+                "whole": self.whole,
+            }
+        )
 
 
 class MDBXCanary(ctypes.Structure):
@@ -1461,18 +1482,16 @@ class MDBXCanary(ctypes.Structure):
     visible outside the current transaction only after it was committed. Current
     values could be retrieved by mdbx_canary_get(). */
     """
-    _fields_ = [("x", ctypes.c_uint64),
-                ("y", ctypes.c_uint64),
-                ("z", ctypes.c_uint64),
-                ("v", ctypes.c_uint64)]
+
+    _fields_ = [
+        ("x", ctypes.c_uint64),
+        ("y", ctypes.c_uint64),
+        ("z", ctypes.c_uint64),
+        ("v", ctypes.c_uint64),
+    ]
 
     def __repr__(self):
-        return str({
-            "x": self.x,
-            "y": self.y,
-            "z": self.z,
-            "v": self.v
-        })
+        return str({"x": self.x, "y": self.y, "z": self.z, "v": self.v})
 
 
 class MDBXTXNInfo(ctypes.Structure):
@@ -1484,7 +1503,7 @@ class MDBXTXNInfo(ctypes.Structure):
         ("txn_space_limit_hard", ctypes.c_uint64),
         ("txn_space_retired", ctypes.c_uint64),
         ("txn_space_leftover", ctypes.c_uint64),
-        ("txn_space_dirty", ctypes.c_uint64)
+        ("txn_space_dirty", ctypes.c_uint64),
     ]
 
 
@@ -1496,8 +1515,8 @@ class Iovec(ctypes.Structure):
     The abstract bindings do not return this type, instead this is used internally to
     communicate with the C API./
     """
-    _fields_ = [("iov_base", ctypes.c_void_p),
-                ("iov_len", ctypes.c_size_t)]
+
+    _fields_ = [("iov_base", ctypes.c_void_p), ("iov_len", ctypes.c_size_t)]
 
     def __init__(self, base: bytes = None, length: int = 0):
         if length < 0:
@@ -1512,7 +1531,9 @@ class Iovec(ctypes.Structure):
         if length == 0:
             return None
         else:
-            return bytes(ctypes.cast(self.iov_base, ctypes.POINTER(ctypes.c_ubyte))[:length])
+            return bytes(
+                ctypes.cast(self.iov_base, ctypes.POINTER(ctypes.c_ubyte))[:length]
+            )
 
     def __repr__(self):
         return "iovec{.iov_base=%s, iov.len=%s}" % (self.iov_base, self.iov_len)
@@ -1522,6 +1543,7 @@ class MDBXEnv(ctypes.Structure):
     """
     Opaque struct used for declaration of Pointer to it
     """
+
     pass
 
 
@@ -1529,6 +1551,7 @@ class MDBXTXN(ctypes.Structure):
     """
     Opaque struct used for declaration of Pointer to it
     """
+
     pass
 
 
@@ -1536,6 +1559,7 @@ class MDBXCursor(ctypes.Structure):
     """
     Opaque struct used for declaration of Pointer to it
     """
+
     pass
 
 
@@ -1543,24 +1567,22 @@ class MDBXDBI(ctypes.Structure):
     """
     Struct in place of a #define, so type requirements can be declared
     """
+
     _fields_ = [("dbi", ctypes.c_uint32)]
 
     def __repr__(self):
-        return str({
-            "dbi": self.dbi
-        })
+        return str({"dbi": self.dbi})
 
 
 class MDBXAttr(ctypes.Structure):
     """
     Struct in place of a #define, so type requirements can be declared
     """
+
     _fields_ = [("attr", ctypes.c_uint64)]
 
     def __repr__(self):
-        return str({
-            "attr": self.attr
-        })
+        return str({"attr": self.attr})
 
 
 class MDBXErrorExc(BaseException):
@@ -1586,7 +1608,9 @@ class TXN:
     An abstraction of the MdbxTxn struct and related functions
     """
 
-    def __init__(self, env: Env, parent: TXN = None, flags: MDBXTXNFlags = 0, context=None):
+    def __init__(
+        self, env: Env, parent: TXN = None, flags: MDBXTXNFlags = 0, context=None
+    ):
         """
 
         Raises MDBXErrorExc or OSError
@@ -1606,13 +1630,15 @@ class TXN:
         self._dependents: List[ReferenceType[Cursor]] = []
         env._dependents.append(weakref.ref(self))
         ret = _lib.mdbx_txn_begin_ex(
-            env._env, parent, flags, ctypes.pointer(self._txn), context)
+            env._env, parent, flags, ctypes.pointer(self._txn), context
+        )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
     def __del__(self):
         logging.getLogger(__name__).debug(
-            f"Transaction {self._txn} being deleted, dependents: {self._dependents}")
+            f"Transaction {self._txn} being deleted, dependents: {self._dependents}"
+        )
         self.close()
 
     def __enter__(self):
@@ -1620,7 +1646,8 @@ class TXN:
 
     def __exit__(self, _1, _2, _3):
         logging.getLogger(__name__).debug(
-            f"Transaction {self._txn} exits, dependents: {self._dependents}")
+            f"Transaction {self._txn} exits, dependents: {self._dependents}"
+        )
         self.close()
 
     def break_txn(self):
@@ -1647,7 +1674,8 @@ class TXN:
         ;rtype bool
         """
         logging.getLogger(__name__).debug(
-            f"Transaction {self._txn} being commit, dependents: {self._dependents}")
+            f"Transaction {self._txn} being commit, dependents: {self._dependents}"
+        )
         if self._txn:
             self.__inform_deps()
             ret = _lib.mdbx_txn_commit(self._txn)
@@ -1666,12 +1694,12 @@ class TXN:
         :rtype MDBXCommitLatency
         """
         logging.getLogger(__name__).debug(
-            f"Transaction {self._txn} being committed_ex, dependents: {self._dependents}")
+            f"Transaction {self._txn} being committed_ex, dependents: {self._dependents}"
+        )
         if self._txn:
             self.__inform_deps()
             commit_latency = MDBXCommitLatency()
-            ret = _lib.mdbx_txn_commit_ex(
-                self._txn, ctypes.byref(commit_latency))
+            ret = _lib.mdbx_txn_commit_ex(self._txn, ctypes.byref(commit_latency))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             self._txn = None
@@ -1800,7 +1828,8 @@ class TXN:
         :rtype bool
         """
         logging.getLogger(__name__).debug(
-            f"Transaction {self._txn} being aborted, dependents: {self._dependents}")
+            f"Transaction {self._txn} being aborted, dependents: {self._dependents}"
+        )
         if self._txn:
             self.__inform_deps()  # It's okay to double-close
             ret = _lib.mdbx_txn_abort(self._txn)
@@ -1811,7 +1840,11 @@ class TXN:
             return True
         return False
 
-    def create_map(self, name: str | bytes | None = None, flags: MDBXDBFlags = MDBXDBFlags.MDBX_CREATE):
+    def create_map(
+        self,
+        name: str | bytes | None = None,
+        flags: MDBXDBFlags = MDBXDBFlags.MDBX_CREATE,
+    ):
         """
         Wrapper around mdbx_dbi_open, intended to create a database(map)
 
@@ -1825,7 +1858,11 @@ class TXN:
         """
         return self.open_map(name, flags | MDBXDBFlags.MDBX_CREATE)
 
-    def open_map(self, name: str | bytes | None = None, flags: MDBXDBFlags = MDBXDBFlags.MDBX_DB_DEFAULTS):
+    def open_map(
+        self,
+        name: str | bytes | None = None,
+        flags: MDBXDBFlags = MDBXDBFlags.MDBX_DB_DEFAULTS,
+    ):
         """
         Wrapper around mdbx_dbi_open, intended to open an existing map
 
@@ -1846,8 +1883,7 @@ class TXN:
                 cname = name
             if cname:
                 cname = ctypes.c_char_p(cname)
-            ret = _lib.mdbx_dbi_open(
-                self._txn, cname, flags, ctypes.pointer(dbi))
+            ret = _lib.mdbx_dbi_open(self._txn, cname, flags, ctypes.pointer(dbi))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             ret = DBI(self._env, MDBXDBI(dbi))
@@ -1866,8 +1902,7 @@ class TXN:
         """
         info = MDBXTXNInfo()
         if self._txn:
-            ret = _lib.mdbx_txn_info(
-                self._txn, ctypes.c_void_p(info), scan_rlt)
+            ret = _lib.mdbx_txn_info(self._txn, ctypes.c_void_p(info), scan_rlt)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return info
@@ -1919,12 +1954,13 @@ class Geometry:
     """
     Storage object for set_geometry and instanciation of Env with passed Env
     """
-    size_lower:         int = -1
-    size_now:           int = -1
-    size_upper:         int = -1
-    growth_step:        int = -1
-    shrink_threshold:   int = -1
-    pagesize:           int = -1
+
+    size_lower: int = -1
+    size_now: int = -1
+    size_upper: int = -1
+    growth_step: int = -1
+    shrink_threshold: int = -1
+    pagesize: int = -1
 
 
 class Env(object):
@@ -1947,16 +1983,17 @@ class Env(object):
 
     """
 
-    def __init__(self,
-                 path: str,
-                 flags: MDBXEnvFlags = 0,
-                 mode: MDBXMode = 0o755,
-                 geometry: Geometry = None,
-                 maxreaders: int = 1,
-                 maxdbs: int = 1,
-                 sync_bytes: int = None,
-                 sync_period: int = None
-                 ):
+    def __init__(
+        self,
+        path: str,
+        flags: MDBXEnvFlags = 0,
+        mode: MDBXMode = 0o755,
+        geometry: Geometry = None,
+        maxreaders: int = 1,
+        maxdbs: int = 1,
+        sync_bytes: int = None,
+        sync_period: int = None,
+    ):
         self._env = ctypes.pointer(MDBXEnv())
         ret = _lib.mdbx_env_create(ctypes.byref(self._env))
         self._default_db = None
@@ -1966,10 +2003,15 @@ class Env(object):
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
         if geometry:
-            ret = _lib.mdbx_env_set_geometry(self._env, geometry.size_lower,
-                                             geometry.size_now, geometry.size_upper,
-                                             geometry.growth_step, geometry.shrink_threshold,
-                                             geometry.pagesize)
+            ret = _lib.mdbx_env_set_geometry(
+                self._env,
+                geometry.size_lower,
+                geometry.size_now,
+                geometry.size_upper,
+                geometry.growth_step,
+                geometry.shrink_threshold,
+                geometry.pagesize,
+            )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
         if maxreaders > 0:
@@ -1980,8 +2022,9 @@ class Env(object):
             ret = _lib.mdbx_env_set_maxdbs(self._env, maxdbs)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
-        ret = _lib.mdbx_env_open(self._env, ctypes.c_char_p(
-            bytes(str(path), "utf-8")), flags, mode)
+        ret = _lib.mdbx_env_open(
+            self._env, ctypes.c_char_p(bytes(str(path), "utf-8")), flags, mode
+        )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
@@ -2001,7 +2044,7 @@ class Env(object):
         self.close()
 
     def __repr__(self):
-        return "Env { \"path\" : \"%s\"}" % self.get_path()
+        return 'Env { "path" : "%s"}' % self.get_path()
 
     def __getitem__(self, key: str | bytes):
         """
@@ -2074,7 +2117,8 @@ class Env(object):
         Raises MDBXErrorExc or OSError
         """
         logging.getLogger(__name__).debug(
-            f"env {self._env} being closed, dependents: {self._dependents}")
+            f"env {self._env} being closed, dependents: {self._dependents}"
+        )
         if self._env:
             for tx in self._dependents:
                 tx = tx()
@@ -2132,8 +2176,7 @@ class Env(object):
         # start transaction and return new object
         if self._env:
             txn = TXN(self, parent_txn, flags)
-            logging.getLogger(__name__).debug(
-                f"Starting transaction {txn._txn}")
+            logging.getLogger(__name__).debug(f"Starting transaction {txn._txn}")
             return txn
 
     def get_path(self):
@@ -2210,7 +2253,8 @@ class Env(object):
         if self._env:
             info = MDBXEnvinfo()
             ret = _lib.mdbx_env_info_ex(
-                self._env, txn._txn, ctypes.byref(info), ctypes.sizeof(info))
+                self._env, txn._txn, ctypes.byref(info), ctypes.sizeof(info)
+            )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return info
@@ -2226,12 +2270,15 @@ class Env(object):
         if self._env:
             stats = MDBXStat()
             ret = _lib.mdbx_env_stat_ex(
-                self._env, txn._txn, ctypes.byref(stats), ctypes.sizeof(stats))
+                self._env, txn._txn, ctypes.byref(stats), ctypes.sizeof(stats)
+            )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return stats
 
-    def copy(self, destination: str, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS):
+    def copy(
+        self, destination: str, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS
+    ):
         """
         Thin wrapper around mdbx_env_copy
 
@@ -2259,7 +2306,8 @@ class Env(object):
                 fd = fd.fileno()
 
             ret = _lib.mdbx_env_copy2fd(
-                self._env, ctypes.c_int(fd), ctypes.c_int(flags))
+                self._env, ctypes.c_int(fd), ctypes.c_int(flags)
+            )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
 
@@ -2294,10 +2342,15 @@ class Env(object):
         :type geometry: Geometry
         """
         if self._env:
-            ret = _lib.mdbx_env_set_geometry(self._env, geometry.size_lower,
-                                             geometry.size_now, geometry.size_upper,
-                                             geometry.growth_step, geometry.shrink_threshold,
-                                             geometry.pagesize)
+            ret = _lib.mdbx_env_set_geometry(
+                self._env,
+                geometry.size_lower,
+                geometry.size_now,
+                geometry.size_upper,
+                geometry.growth_step,
+                geometry.shrink_threshold,
+                geometry.pagesize,
+            )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
 
@@ -2329,8 +2382,7 @@ class Env(object):
         """
         if self._env:
             val = ctypes.c_uint64()
-            ret = _lib.mdbx_env_get_option(
-                self._env, option, ctypes.byref(val))
+            ret = _lib.mdbx_env_get_option(self._env, option, ctypes.byref(val))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return val.value
@@ -2399,7 +2451,8 @@ class Env(object):
         """
         if self._env:
             ret = _lib.mdbx_env_sync_ex(
-                self._env, ctypes.c_bool(force), ctypes.c_bool(nonblock))
+                self._env, ctypes.c_bool(force), ctypes.c_bool(nonblock)
+            )
             if ret != MDBXError.MDBX_RESULT_TRUE.value and ret != 0:
                 raise make_exception(ret)
 
@@ -2520,8 +2573,7 @@ class DBI:
         """
         key = Iovec(key)
         data = Iovec(None, 1)
-        ret = _lib.mdbx_get(txn._txn, self._dbi,
-                            ctypes.byref(key), ctypes.byref(data))
+        ret = _lib.mdbx_get(txn._txn, self._dbi, ctypes.byref(key), ctypes.byref(data))
         if ret == MDBXError.MDBX_NOTFOUND:
             return None
         if ret != MDBXError.MDBX_SUCCESS.value:
@@ -2538,8 +2590,9 @@ class DBI:
         :rtype MDBXStat
         """
         stats = MDBXStat()
-        ret = _lib.mdbx_dbi_stat(txn._txn, self._dbi,
-                                 ctypes.byref(stats), ctypes.sizeof(stats))
+        ret = _lib.mdbx_dbi_stat(
+            txn._txn, self._dbi, ctypes.byref(stats), ctypes.sizeof(stats)
+        )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
         return stats
@@ -2561,8 +2614,13 @@ class DBI:
 
         key_iov = Iovec(key, len(key))
         value_iov = Iovec(value, len(value))
-        ret = _lib.mdbx_put(txn._txn, self._dbi, ctypes.c_void_p(ctypes.addressof(
-            key_iov)), ctypes.c_void_p(ctypes.addressof(value_iov)), flags)
+        ret = _lib.mdbx_put(
+            txn._txn,
+            self._dbi,
+            ctypes.c_void_p(ctypes.addressof(key_iov)),
+            ctypes.c_void_p(ctypes.addressof(value_iov)),
+            flags,
+        )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
@@ -2599,11 +2657,21 @@ class DBI:
         old_data = Iovec()
         key_iovec = Iovec(key)
         new_iovec = Iovec(new_data)
-        ret = _lib.mdbx_replace(txn._txn, self._dbi, ctypes.byref(
-            key_iovec), ctypes.byref(new_iovec), ctypes.byref(old_data), flags)
+        ret = _lib.mdbx_replace(
+            txn._txn,
+            self._dbi,
+            ctypes.byref(key_iovec),
+            ctypes.byref(new_iovec),
+            ctypes.byref(old_data),
+            flags,
+        )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
-        return bytes(ctypes.cast(old_data.iov_base, ctypes.POINTER(ctypes.c_ubyte))[:old_data.iov_len])
+        return bytes(
+            ctypes.cast(old_data.iov_base, ctypes.POINTER(ctypes.c_ubyte))[
+                : old_data.iov_len
+            ]
+        )
 
     def delete(self, txn: TXN, key: bytes, value: bytes = None):
         """
@@ -2619,13 +2687,17 @@ class DBI:
         """
         old_data = Iovec()
         key_iovec = Iovec(key)
-        ret = _lib.mdbx_del(txn._txn, self._dbi, ctypes.byref(
-            key_iovec), ctypes.byref(Iovec(value)) if value else None)
+        ret = _lib.mdbx_del(
+            txn._txn,
+            self._dbi,
+            ctypes.byref(key_iovec),
+            ctypes.byref(Iovec(value)) if value else None,
+        )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
 
-class Cursor():
+class Cursor:
     """
     Abstraction of an MDBX cursor
 
@@ -2651,14 +2723,14 @@ class Cursor():
         self._cursor = ctypes.POINTER(MDBXCursor)()
         ret = None
         if db and txn:
-            ret = _lib.mdbx_cursor_open(
-                txn._txn, db._dbi, ctypes.pointer(self._cursor))
+            ret = _lib.mdbx_cursor_open(txn._txn, db._dbi, ctypes.pointer(self._cursor))
         if ret and ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
         else:
             if not ctypes.cast(self._cursor, ctypes.c_void_p):
                 raise ValueError(
-                    f"The returned cursor pointer {self._cursor} is invalid?!")
+                    f"The returned cursor pointer {self._cursor} is invalid?!"
+                )
             self._cursor.value = _lib.mdbx_cursor_create(ctypes.c_void_p())
             if not self._cursor.value:
                 raise MemoryError()
@@ -2682,8 +2754,7 @@ class Cursor():
         :param db: database to bind to
         :type db: DBI
         """
-        ret = _lib.mdbx_cursor_bind(
-            txn._txn, self._cursor, db._dbi if db else self._db)
+        ret = _lib.mdbx_cursor_bind(txn._txn, self._cursor, db._dbi if db else self._db)
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
@@ -2695,8 +2766,7 @@ class Cursor():
         self.__del__()
 
     def __del__(self):
-        logging.getLogger(__name__).debug(
-            f"Cursor {self._cursor} being deleted")
+        logging.getLogger(__name__).debug(f"Cursor {self._cursor} being deleted")
         self.close()
 
     def __iter__(self):
@@ -2714,20 +2784,30 @@ class Cursor():
             key = Iovec(bytes())
             if not self._started:
                 self._started = True
-                ret = _lib.mdbx_cursor_get(self._cursor, ctypes.pointer(
-                    key), ctypes.pointer(val), MDBXCursorOp.MDBX_FIRST)
+                ret = _lib.mdbx_cursor_get(
+                    self._cursor,
+                    ctypes.pointer(key),
+                    ctypes.pointer(val),
+                    MDBXCursorOp.MDBX_FIRST,
+                )
             else:
-                ret = _lib.mdbx_cursor_get(self._cursor, ctypes.pointer(
-                    key), ctypes.pointer(val), MDBXCursorOp.MDBX_NEXT)
+                ret = _lib.mdbx_cursor_get(
+                    self._cursor,
+                    ctypes.pointer(key),
+                    ctypes.pointer(val),
+                    MDBXCursorOp.MDBX_NEXT,
+                )
 
             if ret != MDBXError.MDBX_SUCCESS.value:
                 if _lib.mdbx_cursor_eof(self._cursor) or ret == MDBXError.MDBX_NOTFOUND:
                     raise StopIteration
                 raise make_exception(ret)
-            val = bytes(ctypes.cast(val.iov_base, ctypes.POINTER(
-                ctypes.c_ubyte))[:val.iov_len])
-            key = bytes(ctypes.cast(key.iov_base, ctypes.POINTER(
-                ctypes.c_ubyte))[:key.iov_len])
+            val = bytes(
+                ctypes.cast(val.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: val.iov_len]
+            )
+            key = bytes(
+                ctypes.cast(key.iov_base, ctypes.POINTER(ctypes.c_ubyte))[: key.iov_len]
+            )
             return key, val
         return None, None
 
@@ -2737,8 +2817,7 @@ class Cursor():
 
         Sets self._cursor to None, invalidating the reference to it
         """
-        logging.getLogger(__name__).debug(
-            f"Cursor {self._cursor} being closed")
+        logging.getLogger(__name__).debug(f"Cursor {self._cursor} being closed")
         if self._cursor:
             _lib.mdbx_cursor_close(self._cursor)
             # This is important to release the strong references
@@ -2819,25 +2898,28 @@ class Cursor():
 
     def first(self) -> Tuple[Optional[bytes], Optional[bytes]]:
         return self.get_full(None, MDBXCursorOp.MDBX_FIRST)
-        
+
     def first_dup(self) -> Optional[bytes]:
         _, v = self.get_full(None, MDBXCursorOp.MDBX_FIRST_DUP)
         return v
-    
+
     def last(self) -> Tuple[Optional[bytes], Optional[bytes]]:
         return self.get_full(None, MDBXCursorOp.MDBX_LAST)
-    
+
     def last_dup(self) -> Optional[bytes]:
         _, v = self.get_full(None, MDBXCursorOp.MDBX_LAST_DUP)
         return v
-    
-    def get_full(self, key: Optional[bytes], cursor_op: MDBXCursorOp) -> Tuple[Optional[bytes], Optional[bytes]]:
+
+    def get_full(
+        self, key: Optional[bytes], cursor_op: MDBXCursorOp
+    ) -> Tuple[Optional[bytes], Optional[bytes]]:
         if self._cursor:
             io_key = Iovec(key)
             io_data = Iovec(None, 1)
 
-            ret = _lib.mdbx_cursor_get(self._cursor, ctypes.byref(
-                io_key), ctypes.byref(io_data), cursor_op)
+            ret = _lib.mdbx_cursor_get(
+                self._cursor, ctypes.byref(io_key), ctypes.byref(io_data), cursor_op
+            )
             if ret == MDBXError.MDBX_NOTFOUND or ret == MDBXError.MDBX_ENODATA:
                 return (None, None)
             if ret != MDBXError.MDBX_SUCCESS.value:
@@ -2845,8 +2927,10 @@ class Cursor():
             out_key = io_key.to_bytes()
             out_value = io_data.to_bytes()
             return (out_key, out_value)
- 
-    def get(self, key: Optional[bytes], cursor_op: MDBXCursorOp = MDBXCursorOp.MDBX_FIRST) -> Optional[bytes]:
+
+    def get(
+        self, key: Optional[bytes], cursor_op: MDBXCursorOp = MDBXCursorOp.MDBX_FIRST
+    ) -> Optional[bytes]:
         """
         Wrapper around mdbx_cursor_get
 
@@ -2861,7 +2945,9 @@ class Cursor():
         _, v = self.get_full(key, cursor_op)
         return v
 
-    def put(self, key: bytes, val: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT):
+    def put(
+        self, key: bytes, val: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT
+    ):
         """
         Thin wrapper around mdbx_cursor_put
 
@@ -2877,8 +2963,9 @@ class Cursor():
             key_iovec = Iovec(key, len(key))
             value_iovec = Iovec(val, len(val))
 
-            ret = _lib.mdbx_cursor_put(self._cursor, ctypes.byref(
-                key_iovec), ctypes.byref(value_iovec), flags)
+            ret = _lib.mdbx_cursor_put(
+                self._cursor, ctypes.byref(key_iovec), ctypes.byref(value_iovec), flags
+            )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
 
@@ -2979,14 +3066,16 @@ class Cursor():
                 raise make_exception(ret)
         return False
 
-    def iter(self,
-             start_key: Optional[bytes] = None,
-             from_next: bool = False,
-             copy_cursor: bool = False
-             ) -> Iterator[Tuple[bytes, bytes]]:
+    def iter(
+        self,
+        start_key: Optional[bytes] = None,
+        from_next: bool = False,
+        copy_cursor: bool = False,
+    ) -> Iterator[Tuple[bytes, bytes]]:
         if start_key is not None and from_next:
             raise RuntimeError(
-                "start_key and from_next can not be used at the same time")
+                "start_key and from_next can not be used at the same time"
+            )
         if copy_cursor:
             cursor = self.dup()
         else:
@@ -3001,22 +3090,25 @@ class Cursor():
             self.get_full(start_key, MDBXCursorOp.MDBX_SET_RANGE)
             return DBIter(cursor, MDBXCursorOp.MDBX_GET_CURRENT, MDBXCursorOp.MDBX_NEXT)
 
-    def iter_dupsort(self,
-                     start_key: Optional[bytes] = None,
-                     from_next: bool = False,
-                     copy_cursor: bool = False
-                     ) -> Iterator[Tuple[bytes, bytes]]:
+    def iter_dupsort(
+        self,
+        start_key: Optional[bytes] = None,
+        from_next: bool = False,
+        copy_cursor: bool = False,
+    ) -> Iterator[Tuple[bytes, bytes]]:
         its = self.iter_dupsort_rows(start_key, from_next, copy_cursor)
         return itertools.chain.from_iterable(its)
 
-    def iter_dupsort_rows(self,
-                          start_key: Optional[bytes] = None,
-                          from_next: bool = False,
-                          copy_cursor: bool = False,
-                          ) -> Iterator[Iterator[Tuple[bytes, bytes]]]:
+    def iter_dupsort_rows(
+        self,
+        start_key: Optional[bytes] = None,
+        from_next: bool = False,
+        copy_cursor: bool = False,
+    ) -> Iterator[Iterator[Tuple[bytes, bytes]]]:
         if start_key is not None and from_next:
             raise RuntimeError(
-                "start_key and from_next can not be used at the same time")
+                "start_key and from_next can not be used at the same time"
+            )
         if copy_cursor:
             cursor = self.dup()
         else:
@@ -3034,7 +3126,9 @@ class Cursor():
 
 class DBIter(object):
 
-    def __init__(self, cur: Cursor, first_op: MDBXCursorOp, second_op: Optional[MDBXCursorOp]):
+    def __init__(
+        self, cur: Cursor, first_op: MDBXCursorOp, second_op: Optional[MDBXCursorOp]
+    ):
         self.cur = cur  # Strong reference!
         self.first_op = first_op
         self.second_op = second_op
@@ -3072,7 +3166,9 @@ class DBDupIter(object):
         if k is None or v is None:
             raise StopIteration
 
-        return DBIter(self.cur.dup(), MDBXCursorOp.MDBX_GET_CURRENT, MDBXCursorOp.MDBX_NEXT_DUP)
+        return DBIter(
+            self.cur.dup(), MDBXCursorOp.MDBX_GET_CURRENT, MDBXCursorOp.MDBX_NEXT_DUP
+        )
 
 
 def get_build_info():
@@ -3101,8 +3197,7 @@ def make_exception(errno: int):
     return OSError(errno, os.strerror(errno))
 
 
-_lib.mdbx_strerror_r.argtypes = [
-    ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t]
+_lib.mdbx_strerror_r.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t]
 _lib.mdbx_strerror_r.restype = ctypes.c_char_p
 _lib.mdbx_liberr2str.argtypes = [ctypes.c_int]
 _lib.mdbx_liberr2str.restype = ctypes.c_char_p
@@ -3110,8 +3205,12 @@ _lib.mdbx_thread_register.argtypes = [ctypes.c_void_p]
 _lib.mdbx_thread_register.restype = ctypes.c_int
 _lib.mdbx_thread_unregister.argtypes = [ctypes.c_void_p]
 _lib.mdbx_thread_unregister.restype = ctypes.c_int
-_lib.mdbx_dbi_open.argtypes = [ctypes.POINTER(
-    MDBXTXN), ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_uint32)]
+_lib.mdbx_dbi_open.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.c_uint32),
+]
 _lib.mdbx_dbi_open.restype = ctypes.c_int
 _lib.mdbx_txn_abort.argtypes = [ctypes.POINTER(MDBXTXN)]
 _lib.mdbx_txn_abort.restype = ctypes.c_int
@@ -3125,50 +3224,86 @@ _lib.mdbx_txn_renew.argtypes = [ctypes.POINTER(MDBXTXN)]
 _lib.mdbx_txn_renew.restype = ctypes.c_int
 _lib.mdbx_txn_commit.argtypes = [ctypes.POINTER(MDBXTXN)]
 _lib.mdbx_txn_commit.restype = ctypes.c_int
-_lib.mdbx_txn_commit_ex.argtypes = [ctypes.POINTER(
-    MDBXTXN), ctypes.POINTER(MDBXCommitLatency)]
+_lib.mdbx_txn_commit_ex.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    ctypes.POINTER(MDBXCommitLatency),
+]
 _lib.mdbx_txn_commit_ex.restype = ctypes.c_int
 _lib.mdbx_txn_id.argtypes = [ctypes.POINTER(MDBXTXN)]
 _lib.mdbx_txn_id.restype = ctypes.c_uint64
 _lib.mdbx_txn_break.argtypes = [ctypes.POINTER(MDBXTXN)]
 _lib.mdbx_txn_break.restype = ctypes.c_int
-_lib.mdbx_txn_begin_ex.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.POINTER(
-    MDBXTXN), ctypes.c_int, ctypes.POINTER(ctypes.POINTER(MDBXTXN)), ctypes.c_void_p]
+_lib.mdbx_txn_begin_ex.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.POINTER(MDBXTXN),
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.POINTER(MDBXTXN)),
+    ctypes.c_void_p,
+]
 _lib.mdbx_txn_begin_ex.restype = ctypes.c_int
-_lib.mdbx_txn_info.argtypes = [ctypes.POINTER(
-    MDBXTXN), ctypes.POINTER(MDBXEnvinfo), ctypes.c_bool]
+_lib.mdbx_txn_info.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    ctypes.POINTER(MDBXEnvinfo),
+    ctypes.c_bool,
+]
 _lib.mdbx_txn_info.restype = ctypes.c_int
 
-_lib.mdbx_canary_get.argtypes = [
-    ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCanary)]
+_lib.mdbx_canary_get.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCanary)]
 _lib.mdbx_canary_get.restype = ctypes.c_int
-_lib.mdbx_canary_put.argtypes = [
-    ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCanary)]
+_lib.mdbx_canary_put.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCanary)]
 _lib.mdbx_canary_put.restype = ctypes.c_int
 
 _lib.MDBX_reader_list_func = ctypes.CFUNCTYPE(ctypes.c_int)
-_lib.MDBX_reader_list_func.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int,
-                                       ctypes.c_int, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_size_t, ctypes.c_size_t]
+_lib.MDBX_reader_list_func.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_uint64,
+    ctypes.c_uint64,
+    ctypes.c_size_t,
+    ctypes.c_size_t,
+]
 _lib.MDBX_reader_list_func.restype = ctypes.c_int
-_lib.mdbx_reader_list.argtypes = [ctypes.POINTER(
-    MDBXEnv), ctypes.POINTER(_lib.MDBX_reader_list_func), ctypes.c_void_p]
+_lib.mdbx_reader_list.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.POINTER(_lib.MDBX_reader_list_func),
+    ctypes.c_void_p,
+]
 _lib.mdbx_reader_list.restype = ctypes.c_int
 _lib.mdbx_drop.argtypes = [ctypes.POINTER(MDBXTXN), MDBXDBI, ctypes.c_void_p]
 _lib.mdbx_drop.restype = ctypes.c_int
-_lib.mdbx_put.argtypes = [ctypes.POINTER(
-    MDBXTXN), MDBXDBI, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
+_lib.mdbx_put.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    MDBXDBI,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
 _lib.mdbx_put.restype = ctypes.c_int
-_lib.mdbx_get.argtypes = [ctypes.POINTER(
-    MDBXTXN), MDBXDBI, ctypes.c_void_p, ctypes.c_void_p]
+_lib.mdbx_get.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    MDBXDBI,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
 _lib.mdbx_get.restype = ctypes.c_int
-_lib.mdbx_del.argtypes = [ctypes.POINTER(
-    MDBXTXN), MDBXDBI, ctypes.c_void_p, ctypes.c_void_p]
+_lib.mdbx_del.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    MDBXDBI,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
 _lib.mdbx_del.restype = ctypes.c_int
 
 _lib.mdbx_env_create.argtypes = [ctypes.POINTER(ctypes.POINTER(MDBXEnv))]
 
-_lib.mdbx_env_open.argtypes = [ctypes.POINTER(
-    MDBXEnv), ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
+_lib.mdbx_env_open.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+]
 _lib.mdbx_env_open.restype = ctypes.c_int
 
 _lib.mdbx_env_close.argtypes = [ctypes.POINTER(MDBXEnv)]
@@ -3176,56 +3311,74 @@ _lib.mdbx_env_close.restype = ctypes.c_int
 
 _lib.mdbx_env_close_ex.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_int]
 
-_lib.mdbx_env_get_path.argtypes = [ctypes.POINTER(
-    MDBXEnv), ctypes.POINTER(ctypes.c_char_p)]
+_lib.mdbx_env_get_path.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.POINTER(ctypes.c_char_p),
+]
 _lib.mdbx_env_get_path.restype = ctypes.c_int
 
 _lib.mdbx_env_get_userctx.argtypes = [ctypes.POINTER(MDBXEnv)]
 _lib.mdbx_env_get_userctx.restype = ctypes.c_void_p
 _lib.mdbx_env_set_userctx.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_void_p]
 _lib.mdbx_env_set_userctx.restype = ctypes.c_int
-_lib.mdbx_env_info_ex.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.POINTER(
-    MDBXTXN), ctypes.POINTER(MDBXEnvinfo), ctypes.c_size_t]
+_lib.mdbx_env_info_ex.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.POINTER(MDBXTXN),
+    ctypes.POINTER(MDBXEnvinfo),
+    ctypes.c_size_t,
+]
 _lib.mdbx_env_info_ex.restype = ctypes.c_int
-_lib.mdbx_env_stat_ex.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.POINTER(
-    MDBXTXN), ctypes.POINTER(MDBXStat), ctypes.c_size_t]
+_lib.mdbx_env_stat_ex.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.POINTER(MDBXTXN),
+    ctypes.POINTER(MDBXStat),
+    ctypes.c_size_t,
+]
 _lib.mdbx_env_stat_ex.restype = ctypes.c_int
 
-_lib.mdbx_env_set_syncperiod.argtypes = [
-    ctypes.POINTER(MDBXEnv), ctypes.c_uint]
+_lib.mdbx_env_set_syncperiod.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_uint]
 _lib.mdbx_env_set_syncperiod.restype = ctypes.c_int
-_lib.mdbx_env_set_syncbytes.argtypes = [
-    ctypes.POINTER(MDBXEnv), ctypes.c_size_t]
+_lib.mdbx_env_set_syncbytes.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_size_t]
 _lib.mdbx_env_set_syncbytes.restype = ctypes.c_int
-_lib.mdbx_env_set_maxreaders.argtypes = [
-    ctypes.POINTER(MDBXEnv), ctypes.c_uint]
+_lib.mdbx_env_set_maxreaders.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_uint]
 _lib.mdbx_env_set_maxreaders.restype = ctypes.c_int
 _lib.mdbx_env_set_maxdbs.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_uint]
 _lib.mdbx_env_set_maxdbs.restype = ctypes.c_int
 _lib.mdbx_env_get_maxdbs.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_void_p]
 _lib.mdbx_env_get_maxdbs.restype = ctypes.c_int
-_lib.mdbx_env_set_geometry.argtypes = [ctypes.POINTER(
-    MDBXEnv), ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+_lib.mdbx_env_set_geometry.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
 _lib.mdbx_env_set_geometry.restype = ctypes.c_int
-_lib.mdbx_env_set_flags.argtypes = [
-    ctypes.POINTER(MDBXEnv), ctypes.c_int, ctypes.c_int]
+_lib.mdbx_env_set_flags.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_int, ctypes.c_int]
 _lib.mdbx_env_set_flags.restype = ctypes.c_int
 _lib.mdbx_env_get_flags.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_void_p]
 _lib.mdbx_env_get_flags.restype = ctypes.c_int
 
-_lib.mdbx_env_sync_ex.argtypes = [
-    ctypes.POINTER(MDBXEnv), ctypes.c_bool, ctypes.c_bool]
+_lib.mdbx_env_sync_ex.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.c_bool, ctypes.c_bool]
 _lib.mdbx_env_sync_ex.restype = ctypes.c_int
-_lib.mdbx_cursor_open.argtypes = [ctypes.POINTER(
-    MDBXTXN), MDBXDBI, ctypes.POINTER(ctypes.POINTER(MDBXCursor))]
+_lib.mdbx_cursor_open.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    MDBXDBI,
+    ctypes.POINTER(ctypes.POINTER(MDBXCursor)),
+]
 _lib.mdbx_cursor_open.restype = ctypes.c_int
 _lib.mdbx_cursor_dbi.argtypes = [ctypes.POINTER(MDBXCursor)]
 _lib.mdbx_cursor_dbi.restype = ctypes.c_longlong
-_lib.mdbx_cursor_get.argtypes = [ctypes.POINTER(
-    MDBXCursor), ctypes.POINTER(Iovec), ctypes.POINTER(Iovec), MDBXCursorOp]
+_lib.mdbx_cursor_get.argtypes = [
+    ctypes.POINTER(MDBXCursor),
+    ctypes.POINTER(Iovec),
+    ctypes.POINTER(Iovec),
+    MDBXCursorOp,
+]
 _lib.mdbx_cursor_get.restype = ctypes.c_int
-_lib.mdbx_cursor_set_userctx.argtypes = [
-    ctypes.POINTER(MDBXCursor), ctypes.c_void_p]
+_lib.mdbx_cursor_set_userctx.argtypes = [ctypes.POINTER(MDBXCursor), ctypes.c_void_p]
 _lib.mdbx_cursor_set_userctx.restype = ctypes.c_int
 _lib.mdbx_cursor_set_userctx.argtypes = [ctypes.POINTER(MDBXCursor)]
 _lib.mdbx_cursor_get_userctx.restype = ctypes.c_void_p
@@ -3234,25 +3387,35 @@ _lib.mdbx_cursor_txn.restype = ctypes.POINTER(MDBXTXN)
 _lib.mdbx_cursor_dbi.argtypes = [ctypes.POINTER(MDBXCursor)]
 _lib.mdbx_cursor_dbi.restype = ctypes.POINTER(MDBXDBI)
 _lib.mdbx_cursor_copy.argtypes = [
-    ctypes.POINTER(MDBXCursor), ctypes.POINTER(MDBXCursor)]
+    ctypes.POINTER(MDBXCursor),
+    ctypes.POINTER(MDBXCursor),
+]
 _lib.mdbx_cursor_copy.restype = ctypes.c_int
 
 _lib.mdbx_cursor_create.argtypes = [ctypes.c_void_p]
 _lib.mdbx_cursor_create.restype = ctypes.POINTER(MDBXCursor)
-_lib.mdbx_cursor_bind.argtypes = [ctypes.POINTER(
-    MDBXTXN), ctypes.POINTER(MDBXCursor), MDBXDBI]
+_lib.mdbx_cursor_bind.argtypes = [
+    ctypes.POINTER(MDBXTXN),
+    ctypes.POINTER(MDBXCursor),
+    MDBXDBI,
+]
 _lib.mdbx_cursor_bind.restype = ctypes.c_int
 _lib.mdbx_cursor_close.argtypes = [ctypes.POINTER(MDBXCursor)]
-_lib.mdbx_cursor_renew.argtypes = [
-    ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCursor)]
+_lib.mdbx_cursor_renew.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCursor)]
 _lib.mdbx_cursor_renew.restype = ctypes.c_int
-_lib.mdbx_cursor_put.argtypes = [ctypes.POINTER(
-    MDBXCursor), ctypes.POINTER(Iovec), ctypes.POINTER(Iovec), MDBXPutFlags]
+_lib.mdbx_cursor_put.argtypes = [
+    ctypes.POINTER(MDBXCursor),
+    ctypes.POINTER(Iovec),
+    ctypes.POINTER(Iovec),
+    MDBXPutFlags,
+]
 _lib.mdbx_cursor_put.restype = ctypes.c_int
 _lib.mdbx_cursor_del.argtypes = [ctypes.POINTER(MDBXCursor), MDBXPutFlags]
 _lib.mdbx_cursor_del.restype = ctypes.c_int
-_lib.mdbx_cursor_count.argtypes = [ctypes.POINTER(
-    MDBXCursor), ctypes.POINTER(ctypes.c_size_t)]
+_lib.mdbx_cursor_count.argtypes = [
+    ctypes.POINTER(MDBXCursor),
+    ctypes.POINTER(ctypes.c_size_t),
+]
 _lib.mdbx_cursor_count.restype = ctypes.c_int
 _lib.mdbx_cursor_eof.argtypes = [ctypes.POINTER(MDBXCursor)]
 _lib.mdbx_cursor_eof.restype = ctypes.c_int
@@ -3265,43 +3428,77 @@ _lib.mdbx_dbi_close.argtypes = [ctypes.POINTER(MDBXEnv), MDBXDBI]
 _lib.mdbx_dbi_close.restype = ctypes.c_int
 
 try:
-    _lib.mdbx_cursor_put_attr.argtypes = [ctypes.POINTER(MDBXCursor), ctypes.POINTER(
-        Iovec), ctypes.POINTER(Iovec), MDBXAttr, MDBXPutFlags]
+    _lib.mdbx_cursor_put_attr.argtypes = [
+        ctypes.POINTER(MDBXCursor),
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(Iovec),
+        MDBXAttr,
+        MDBXPutFlags,
+    ]
     _lib.mdbx_cursor_put_attr.restype = ctypes.c_int
 except:
     pass
 
 try:
-    _lib.mdbx_put_attr.argtypes = [ctypes.POINTER(MDBXTXN), MDBXDBI, ctypes.POINTER(
-        Iovec), ctypes.POINTER(Iovec), MDBXAttr, MDBXPutFlags]
+    _lib.mdbx_put_attr.argtypes = [
+        ctypes.POINTER(MDBXTXN),
+        MDBXDBI,
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(Iovec),
+        MDBXAttr,
+        MDBXPutFlags,
+    ]
     _lib.mdbx_put_attr.restype = ctypes.c_int
 except:
     pass
 
 try:
-    _lib.mdbx_set_attr.argtypes = [ctypes.POINTER(
-        MDBXTXN), MDBXDBI, ctypes.POINTER(Iovec), ctypes.POINTER(Iovec), MDBXAttr]
+    _lib.mdbx_set_attr.argtypes = [
+        ctypes.POINTER(MDBXTXN),
+        MDBXDBI,
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(Iovec),
+        MDBXAttr,
+    ]
     _lib.mdbx_set_attr.restype = ctypes.c_int
 except:
     pass
 
 try:
-    _lib.mdbx_cursor_get_attr.argtypes = [ctypes.POINTER(MDBXCursor), ctypes.POINTER(
-        Iovec), ctypes.POINTER(Iovec), ctypes.POINTER(MDBXAttr), MDBXCursorOp]
+    _lib.mdbx_cursor_get_attr.argtypes = [
+        ctypes.POINTER(MDBXCursor),
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(MDBXAttr),
+        MDBXCursorOp,
+    ]
     _lib.mdbx_cursor_get_attr.restype = ctypes.c_int
 except:
     pass
 
 try:
-    _lib.mdbx_get_attr.argtypes = [ctypes.POINTER(MDBXTXN), MDBXDBI, ctypes.POINTER(
-        Iovec), ctypes.POINTER(Iovec), ctypes.POINTER(MDBXAttr)]
+    _lib.mdbx_get_attr.argtypes = [
+        ctypes.POINTER(MDBXTXN),
+        MDBXDBI,
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(Iovec),
+        ctypes.POINTER(MDBXAttr),
+    ]
     _lib.mdbx_get_attr.restype = ctypes.c_int
 except:
     pass
 
 _lib.MDBX_hsr_func = ctypes.CFUNCTYPE(ctypes.c_int)
-_lib.MDBX_hsr_func.argtypes = [ctypes.POINTER(MDBXEnv), ctypes.POINTER(
-    MDBXTXN), ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_uint, ctypes.c_size_t, ctypes.c_int]
+_lib.MDBX_hsr_func.argtypes = [
+    ctypes.POINTER(MDBXEnv),
+    ctypes.POINTER(MDBXTXN),
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_uint64,
+    ctypes.c_uint,
+    ctypes.c_size_t,
+    ctypes.c_int,
+]
 _lib.MDBX_hsr_func.restype = ctypes.c_int
 
 
@@ -3311,8 +3508,7 @@ _lib.mdbx_limits_dbsize_max.restype = ctypes.POINTER(ctypes.c_int)
 _lib.mdbx_limits_dbsize_min.argtypes = [ctypes.POINTER(ctypes.c_int)]
 _lib.mdbx_limits_dbsize_min.restype = ctypes.POINTER(ctypes.c_int)
 
-_lib.mdbx_limits_keysize_max.argtypes = [
-    ctypes.POINTER(ctypes.c_int), MDBXDBFlags]
+_lib.mdbx_limits_keysize_max.argtypes = [ctypes.POINTER(ctypes.c_int), MDBXDBFlags]
 _lib.mdbx_limits_keysize_max.restype = ctypes.POINTER(ctypes.c_int)
 
 _lib.mdbx_limits_pgsize_max.argtypes = []
@@ -3324,18 +3520,22 @@ _lib.mdbx_limits_pgsize_min.restype = ctypes.POINTER(ctypes.c_int)
 _lib.mdbx_limits_txnsize_max.argtypes = [ctypes.POINTER(ctypes.c_int)]
 _lib.mdbx_limits_txnsize_max.restype = ctypes.POINTER(ctypes.c_int)
 
-_lib.mdbx_limits_valsize_max.argtypes = [
-    ctypes.POINTER(ctypes.c_int), MDBXDBFlags]
+_lib.mdbx_limits_valsize_max.argtypes = [ctypes.POINTER(ctypes.c_int), MDBXDBFlags]
 _lib.mdbx_limits_valsize_max.restype = ctypes.POINTER(ctypes.c_int)
 
 
 _lib.mdbx_is_readahead_reasonable.argtypes = [
-    ctypes.c_size_t, ctypes.POINTER(ctypes.c_int)]
+    ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_int),
+]
 _lib.mdbx_is_readahead_reasonable.restype = ctypes.c_int
 
 try:
-    _lib.mdbx_get_sysraminfo.argtypes = [ctypes.POINTER(
-        ctypes.c_int), ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int)]
+    _lib.mdbx_get_sysraminfo.argtypes = [
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+    ]
     _lib.mdbx_get_sysraminfo.restype = ctypes.c_int
 except:
     pass
@@ -3344,5 +3544,7 @@ _lib.mdbx_is_dirty.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.c_void_p]
 _lib.mdbx_is_dirty.restype = ctypes.c_int
 
 _lib.mdbx_txn_straggler.argtypes = [
-    ctypes.POINTER(MDBXTXN), ctypes.POINTER(ctypes.c_int)]
+    ctypes.POINTER(MDBXTXN),
+    ctypes.POINTER(ctypes.c_int),
+]
 _lib.mdbx_txn_straggler.restype = ctypes.c_int

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1906,7 +1906,7 @@ class TXN:
         """
         info = MDBXTXNInfo()
         if self._txn:
-            ret = _lib.mdbx_txn_info(self._txn, ctypes.c_void_p(info), scan_rlt)
+            ret = _lib.mdbx_txn_info(self._txn, ctypes.byref(info), scan_rlt)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return info
@@ -3241,7 +3241,7 @@ _lib.mdbx_txn_begin_ex.argtypes = [
 _lib.mdbx_txn_begin_ex.restype = ctypes.c_int
 _lib.mdbx_txn_info.argtypes = [
     ctypes.POINTER(MDBXTXN),
-    ctypes.POINTER(MDBXEnvinfo),
+    ctypes.POINTER(MDBXTXNInfo),
     ctypes.c_bool,
 ]
 _lib.mdbx_txn_info.restype = ctypes.c_int

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2001,7 +2001,7 @@ class Env(object):
     ):
         self._env = ctypes.pointer(MDBXEnv())
         ret = _lib.mdbx_env_create(ctypes.byref(self._env))
-        self._default_db = None
+        self._default_db: str | bytes | None = None
         self._current_txn = None
         self._dependents: List[ReferenceType[TXN] | ReferenceType[DBI]] = []
         self._ctx: Optional[Any] = None
@@ -2152,7 +2152,7 @@ class Env(object):
         """
         return self.__getitem__(key)
 
-    def set_default_db(self, name: str | bytes):
+    def set_default_db(self, name: str | bytes | None):
         """
         Sets the default DB to be used for __setitem__ and __getitem__
         :param name: name of the DBI

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1875,9 +1875,9 @@ class TXN:
         :rtype DBI in case of success, or bool in case of failure
         """
         if self._txn:
+            cname: Optional[bytes]
             dbi = ctypes.c_uint32()
             dbi.value = 0
-            cname: Optional[bytes]
             if isinstance(name, str):
                 cname = name.encode("utf-8")
             else:
@@ -3247,8 +3247,8 @@ _lib.mdbx_canary_get.restype = ctypes.c_int
 _lib.mdbx_canary_put.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.POINTER(MDBXCanary)]
 _lib.mdbx_canary_put.restype = ctypes.c_int
 
-_lib.MDBX_reader_list_func = ctypes.CFUNCTYPE(ctypes.c_int)
-_lib.MDBX_reader_list_func.argtypes = [
+MDBX_reader_list_func = ctypes.CFUNCTYPE(ctypes.c_int)
+MDBX_reader_list_func.argtypes = [
     ctypes.c_void_p,
     ctypes.c_int,
     ctypes.c_int,
@@ -3258,10 +3258,10 @@ _lib.MDBX_reader_list_func.argtypes = [
     ctypes.c_size_t,
     ctypes.c_size_t,
 ]
-_lib.MDBX_reader_list_func.restype = ctypes.c_int
+MDBX_reader_list_func.restype = ctypes.c_int
 _lib.mdbx_reader_list.argtypes = [
     ctypes.POINTER(MDBXEnv),
-    ctypes.POINTER(_lib.MDBX_reader_list_func),
+    ctypes.POINTER(MDBX_reader_list_func),
     ctypes.c_void_p,
 ]
 _lib.mdbx_reader_list.restype = ctypes.c_int

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2063,7 +2063,7 @@ class Env(object):
             val = db.get(txn, key)
             txn.abort()
             return val
-        except Exception as e:
+        except Exception as _e:
             return None
 
     def __setitem__(self, key: str | bytes, val: str | bytes):
@@ -3468,7 +3468,7 @@ try:
         ctypes.c_uint,
     ]
     _lib.mdbx_cursor_put_attr.restype = ctypes.c_int
-except:
+except:  # noqa: E722
     pass
 
 try:
@@ -3481,7 +3481,7 @@ try:
         ctypes.c_uint,
     ]
     _lib.mdbx_put_attr.restype = ctypes.c_int
-except:
+except:  # noqa: E722
     pass
 
 try:
@@ -3493,7 +3493,7 @@ try:
         MDBXAttr,
     ]
     _lib.mdbx_set_attr.restype = ctypes.c_int
-except:
+except:  # noqa: E722
     pass
 
 try:
@@ -3505,7 +3505,7 @@ try:
         ctypes.c_uint,
     ]
     _lib.mdbx_cursor_get_attr.restype = ctypes.c_int
-except:
+except:  # noqa: E722
     pass
 
 try:
@@ -3517,7 +3517,7 @@ try:
         ctypes.POINTER(MDBXAttr),
     ]
     _lib.mdbx_get_attr.restype = ctypes.c_int
-except:
+except:  # noqa: E722
     pass
 
 MDBX_hsr_func = ctypes.CFUNCTYPE(
@@ -3581,7 +3581,7 @@ try:
         ctypes.POINTER(ctypes.c_int),
     ]
     _lib.mdbx_get_sysraminfo.restype = ctypes.c_int
-except:
+except:  # noqa: E722
     pass
 
 _lib.mdbx_is_dirty.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.c_void_p]

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1749,7 +1749,7 @@ class TXN:
         if self._txn:
             ret = _lib.mdbx_txn_set_userctx(self._txn, ctx)
             if ret != MDBXError.MDBX_SUCCESS.value:
-                raise MDBXErrorExc(ret)
+                raise make_exception(ret)
             return True
         return False
 

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -3368,7 +3368,7 @@ _lib.mdbx_cursor_get.argtypes = [
     ctypes.POINTER(MDBXCursor),
     ctypes.POINTER(Iovec),
     ctypes.POINTER(Iovec),
-    MDBXCursorOp,
+    ctypes.c_uint,
 ]
 _lib.mdbx_cursor_get.restype = ctypes.c_int
 _lib.mdbx_cursor_set_userctx.argtypes = [ctypes.POINTER(MDBXCursor), ctypes.c_void_p]
@@ -3463,7 +3463,7 @@ try:
         ctypes.POINTER(Iovec),
         ctypes.POINTER(Iovec),
         ctypes.POINTER(MDBXAttr),
-        MDBXCursorOp,
+        ctypes.c_uint,
     ]
     _lib.mdbx_cursor_get_attr.restype = ctypes.c_int
 except:

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -2576,15 +2576,15 @@ class DBI:
         :param key: Key to lookup
         :type key: bytes
         """
-        key = Iovec(key)
-        data = Iovec(None, 1)
-        ret = _lib.mdbx_get(txn._txn, self._dbi, ctypes.byref(key), ctypes.byref(data))
+        key_iovec = Iovec(key)
+        data_iovec = Iovec(None, 1)
+        ret = _lib.mdbx_get(txn._txn, self._dbi, ctypes.byref(key_iovec), ctypes.byref(data_iovec))
         if ret == MDBXError.MDBX_NOTFOUND:
             return None
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
 
-        return data.to_bytes()
+        return data_iovec.to_bytes()
 
     def get_stat(self, txn: TXN) -> MDBXStat:
         """

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1939,14 +1939,15 @@ class TXN:
         Creata a cursor on a database. If the argument is str and current transaction is a read-write
         transaction, the database will be created.
         """
+        dbi: DBI | None
         if isinstance(db, str):
             if self._flags.is_read_only():
-                db = self.open_map(db)
+                dbi = self.open_map(db)
             else:
-                db = self.create_map(db)
+                dbi = self.create_map(db)
         elif db is None:
-            db = self.open_map(db)
-        return Cursor(db, self, self._ctx)
+            dbi = self.open_map(db)
+        return Cursor(dbi, self, self._ctx)
 
 
 @dataclasses.dataclass

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1609,7 +1609,7 @@ class TXN:
     """
 
     def __init__(
-        self, env: Env, parent: Optional[TXN] = None, flags: MDBXTXNFlags = 0, context=None
+        self, env: Env, parent: Optional[TXN] = None, flags: MDBXTXNFlags = 0, ctx: Optional[Any] = None
     ):
         """
 
@@ -1625,12 +1625,12 @@ class TXN:
         """
         self._txn = ctypes.POINTER(MDBXTXN)()
         self._env = env
-        self._ctx = None
+        self._ctx: Optional[Any] = ctx
         self._flags = flags
         self._dependents: List[ReferenceType[Cursor]] = []
         env._dependents.append(weakref.ref(self))
         ret = _lib.mdbx_txn_begin_ex(
-            env._env, parent, flags, ctypes.pointer(self._txn), context
+            env._env, parent, flags, ctypes.pointer(self._txn), self._ctx
         )
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
@@ -1723,7 +1723,7 @@ class TXN:
         """
         return self._env
 
-    def set_user_ctx(self, ctx):
+    def set_user_ctx(self, ctx: Any) -> None:
         """
         Sets the user context of the TXN
 
@@ -1734,7 +1734,7 @@ class TXN:
         """
         self._ctx = ctx
 
-    def set_user_ctx_int(self, ctx):
+    def set_user_ctx_int(self, ctx: ctypes.c_void_p):
         """
         Thin wrapper around mdbx_txn_set_userctx
 
@@ -1753,7 +1753,7 @@ class TXN:
             return True
         return False
 
-    def get_user_ctx(self):
+    def get_user_ctx(self) -> Optional[Any]:
         """
         Returns the reference to the stored userctx
 
@@ -1999,7 +1999,7 @@ class Env(object):
         self._default_db = None
         self._current_txn = None
         self._dependents: List[ReferenceType[TXN] | ReferenceType[DBI]] = []
-        self._ctx = None
+        self._ctx: Optional[Any] = None
         if ret != MDBXError.MDBX_SUCCESS.value:
             raise make_exception(ret)
         if geometry:
@@ -2194,7 +2194,7 @@ class Env(object):
                 raise make_exception(ret)
             return ptr.value.decode("utf-8")
 
-    def set_user_ctx(self, val):
+    def set_user_ctx(self, val: Any) -> None:
         """
         Store val in self._ctx
 
@@ -2205,7 +2205,7 @@ class Env(object):
         """
         self._ctx = val
 
-    def get_user_ctx(self):
+    def get_user_ctx(self) -> Optional[Any]:
         """
         Retrieve self._ctx
 
@@ -2215,7 +2215,7 @@ class Env(object):
         """
         return self._ctx
 
-    def set_user_ctx_int(self, val: ctypes.c_void_p):
+    def set_user_ctx_int(self, val: ctypes.c_void_p) -> None:
         """
         Thin wrapper around mdbx_env_set_userctx
         Store val in self._ctx
@@ -2718,7 +2718,7 @@ class Cursor:
         """
         self._db = db
         self._txn = txn
-        self._ctx = ctx
+        self._ctx: Optional[Any] = ctx
         self._started = False
         self._cursor = ctypes.POINTER(MDBXCursor)()
         ret = None
@@ -2818,13 +2818,13 @@ class Cursor:
             self._txn = None
             self._db = None
 
-    def set_user_ctx(self, val):
+    def set_user_ctx(self, val: Any) -> None:
         """
         Sets self._ctx to val
         """
         self._ctx = val
 
-    def get_user_ctx(self):
+    def get_user_ctx(self) -> Optional[Any]:
         """
         Returns self._ctx
         :returns self._ctx

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1910,7 +1910,7 @@ class TXN:
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return info
-        return None
+        raise RuntimeError("TXN is not available")
 
     def get_canary(self) -> MDBXCanary:
         """

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1706,6 +1706,7 @@ class TXN:
             self._txn = None
             self._env = None
             return commit_latency
+        raise RuntimeError("TXN is not available")
 
     def id(self) -> int:
         """
@@ -1752,7 +1753,7 @@ class TXN:
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return True
-        return False
+        raise RuntimeError("TXN is not available")
 
     def get_user_ctx(self) -> Optional[Any]:
         """
@@ -1773,6 +1774,7 @@ class TXN:
         """
         if self._txn:
             return _lib.mdbx_txn_get_userctx(self._txn)
+        raise RuntimeError("TXN is not available")
 
     def renew(self):
         """
@@ -1788,7 +1790,7 @@ class TXN:
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return True
-        return False
+        raise RuntimeError("TXN is not available")
 
     def reset(self):
         """
@@ -1804,7 +1806,7 @@ class TXN:
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return True
-        return False
+        raise RuntimeError("TXN is not available")
 
     def __inform_deps(self):
         for cur in self._dependents:
@@ -1839,7 +1841,7 @@ class TXN:
             self._txn = None
             self._env = None
             return True
-        return False
+        raise RuntimeError("TXN is not available")
 
     def create_map(
         self,
@@ -1863,7 +1865,7 @@ class TXN:
         self,
         name: Optional[str | bytes | None] = None,
         flags: MDBXDBFlags = MDBXDBFlags.MDBX_DB_DEFAULTS,
-    ):
+    ) -> DBI:
         """
         Wrapper around mdbx_dbi_open, intended to open an existing map
 
@@ -1890,9 +1892,8 @@ class TXN:
 
             # self._env should never be None, but like self._tnx will be None upon close
             assert self._env
-            ret = DBI(self._env, MDBXDBI(dbi))
-            return ret
-        return False
+            return DBI(self._env, MDBXDBI(dbi))
+        raise RuntimeError("TXN is not available")
 
     def get_info(self, scan_rlt: bool = False) -> MDBXTXNInfo:
         """
@@ -2233,6 +2234,8 @@ class Env(object):
             ret = _lib.mdbx_env_set_userctx(self._env, val)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
     def get_user_ctx_int(self) -> ctypes.c_void_p:
         """
@@ -2244,6 +2247,7 @@ class Env(object):
         """
         if self._env:
             return _lib.mdbx_env_get_userctx(self._env)
+        raise RuntimeError("Env is not available")
 
     def get_info(self, txn: TXN) -> MDBXEnvinfo:
         """
@@ -2263,6 +2267,7 @@ class Env(object):
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return info
+        raise RuntimeError("Env is not available")
 
     def get_stat(self, txn: TXN) -> MDBXStat:
         """
@@ -2280,10 +2285,11 @@ class Env(object):
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return stats
+        raise RuntimeError("Env is not available")
 
     def copy(
         self, destination: str, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS
-    ):
+    ) -> None:
         """
         Thin wrapper around mdbx_env_copy
 
@@ -2295,8 +2301,10 @@ class Env(object):
             ret = _lib.mdbx_env_copy(self._env, destination, flags)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
-    def copy2fd(self, fd: int, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS):
+    def copy2fd(self, fd: int, flags: MDBXCopyMode = MDBXCopyMode.MDBX_CP_DEFAULTS) -> None:
         """
         Thin wrapper around mdbx_env_copy2fd
 
@@ -2315,8 +2323,10 @@ class Env(object):
             )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
-    def register_thread(self):
+    def register_thread(self) -> None:
         """
         Thin wrapper around mdbx_thread_register
 
@@ -2326,8 +2336,10 @@ class Env(object):
             ret = _lib.mdbx_thread_register(self._env)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
-    def unregister_thread(self):
+    def unregister_thread(self) -> None:
         """
         Thin wrapper around mdbx_unregister_thread
 
@@ -2337,8 +2349,10 @@ class Env(object):
             ret = _lib.mdbx_thread_unregister(self._env)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
-    def set_geometry(self, geometry: Geometry):
+    def set_geometry(self, geometry: Geometry) -> None:
         """
         Thin wrapper around mdbx_env_set_geometry
 
@@ -2358,8 +2372,10 @@ class Env(object):
             )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
-    def set_option(self, option: int, value: int) -> bool:
+    def set_option(self, option: int, value: int) -> None:
         """
         Thin wrapper around mdbx_env_set_option
 
@@ -2374,6 +2390,8 @@ class Env(object):
             ret = _lib.mdbx_env_set_option(self._env, option, val)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
     def get_option(self, option: int) -> int:
         """
@@ -2391,6 +2409,7 @@ class Env(object):
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return val.value
+        raise RuntimeError("Env is not available")
 
     def get_fd(self) -> int:
         """
@@ -2406,6 +2425,7 @@ class Env(object):
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return fd.value
+        raise RuntimeError("Env is not available")
 
     def get_maxdbs(self) -> int:
         """
@@ -2421,6 +2441,7 @@ class Env(object):
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return val.value
+        raise RuntimeError("Env is not available")
 
     def get_maxkeysize(self, flags: int = 0):
         """
@@ -2432,8 +2453,9 @@ class Env(object):
         if self._env:
             val = _lib.mdbx_env_get_maxkeysize_ex(self._env, flags)
             return None if val == -1 else val
+        raise RuntimeError("Env is not available")
 
-    def get_maxvalsize(self, flags: int = 0):
+    def get_maxvalsize(self, flags: int = 0) -> Optional[int]:
         """
         Thin wrapper around mdbx_env_get_maxvalsize_ex
 
@@ -2443,8 +2465,9 @@ class Env(object):
         if self._env:
             val = _lib.mdbx_env_get_maxvalsize_ex(self._env, flags)
             return None if val == -1 else val
+        raise RuntimeError("Env is not available")
 
-    def sync(self, force: bool = False, nonblock: bool = False):
+    def sync(self, force: bool = False, nonblock: bool = False) -> None:
         """
         Thin wrapper around mdbx_env_sync_ex
 
@@ -2460,6 +2483,8 @@ class Env(object):
             )
             if ret != MDBXError.MDBX_RESULT_TRUE.value and ret != 0:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Env is not available")
 
     def get_db_names(self):
         """
@@ -2481,6 +2506,7 @@ class Env(object):
             for key, val in cursor:
                 names.append(key.decode("utf-8"))
             return names
+        raise RuntimeError("Env is not available")
 
     @classmethod
     def delete(cls, path: str, mode: int = 0):
@@ -2515,6 +2541,7 @@ class Env(object):
             ret = _lib.mdbx_env_set_hsr(self._env, ctypes.byref(hsr))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+        raise RuntimeError("Env is not available")
 
     def get_hsr(self) -> _lib.MDBX_hsr_func:
         """
@@ -2526,6 +2553,7 @@ class Env(object):
             ptr = _lib.MDBX_hsr_func()
             ptr.value = _lib.mdbx_env_get_hsr(self._env)
             return ctypes.cast(ptr, _lib.MDBX_hsr_func)
+        raise RuntimeError("Env is not available")
 
 
 class DBI:
@@ -2848,6 +2876,7 @@ class Cursor:
             ret = _lib.mdbx_cursor_set_userctx(self._cursor, ptr)
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+        raise RuntimeError("Cursor is not available")
 
     def get_user_ctx_int(self) -> ctypes.c_void_p:
         """
@@ -2856,6 +2885,7 @@ class Cursor:
         """
         if self._cursor:
             return _lib.mdbx_cursor_get_userctx(self._cursor)
+        raise RuntimeError("Cursor is not available")
 
     def txn(self) -> MDBXTXN:
         """
@@ -2865,6 +2895,7 @@ class Cursor:
         """
         if self._cursor:
             return _lib.mdbx_cursor_txn(self._cursor)
+        raise RuntimeError("Cursor is not available")
 
     def dbi(self) -> MDBXDBI:
         """
@@ -2874,6 +2905,7 @@ class Cursor:
         """
         if self._cursor:
             return _lib.mdbx_cursor_dbi(self._cursor)
+        raise RuntimeError("Cursor is not available")
 
     def copy(self, dest: Cursor) -> Cursor:
         """
@@ -2927,6 +2959,7 @@ class Cursor:
             out_key = io_key.to_bytes()
             out_value = io_data.to_bytes()
             return (out_key, out_value)
+        raise RuntimeError("Cursor is not available")
 
     def get(
         self, key: Optional[bytes], cursor_op: MDBXCursorOp = MDBXCursorOp.MDBX_FIRST
@@ -2947,7 +2980,7 @@ class Cursor:
 
     def put(
         self, key: bytes, val: bytes, flags: MDBXPutFlags = MDBXPutFlags.MDBX_UPSERT
-    ):
+    ) -> None:
         """
         Thin wrapper around mdbx_cursor_put
 
@@ -2968,8 +3001,10 @@ class Cursor:
             )
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+            return
+        raise RuntimeError("Cursor is not available")
 
-    def delete(self, cursor_op: MDBXCursorOp = MDBXCursorOp.MDBX_FIRST):
+    def delete(self, cursor_op: MDBXCursorOp = MDBXCursorOp.MDBX_FIRST) -> None:
         """
         Thin wrapper around mdbx_cursor_del
 
@@ -2977,9 +3012,12 @@ class Cursor:
         :param cursor_op: op parameter to mdbx_cursor_delete
         :type cursor_op: MDBXCursorOP
         """
-        ret = _lib.mdbx_cursor_del(self._cursor, cursor_op)
-        if ret != MDBXError.MDBX_SUCCESS.value:
-            raise make_exception(ret)
+        if self._cursor:
+            ret = _lib.mdbx_cursor_del(self._cursor, cursor_op)
+            if ret != MDBXError.MDBX_SUCCESS.value:
+                raise make_exception(ret)
+            return
+        raise RuntimeError("Cursor is not available")
 
     def count(self) -> int:
         """
@@ -2995,6 +3033,7 @@ class Cursor:
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             return int(count)
+        raise RuntimeError("Cursor is not available")
 
     def eof(self) -> bool:
         """
@@ -3013,6 +3052,7 @@ class Cursor:
                 return False
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+        raise RuntimeError("Cursor is not available")
 
     def on_first(self) -> bool:
         """
@@ -3030,7 +3070,7 @@ class Cursor:
                 return False
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
-        return False
+        raise RuntimeError("Cursor is not available")
 
     def on_last(self) -> bool:
         """
@@ -3048,7 +3088,7 @@ class Cursor:
                 return False
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
-        return False
+        raise RuntimeError("Cursor is not available")
 
     def renew(self, txn: TXN):
         """
@@ -3064,7 +3104,7 @@ class Cursor:
                 return True
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
-        return False
+        raise RuntimeError("Cursor is not available")
 
     def iter(
         self,

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -25,7 +25,7 @@ import os
 from pathlib import Path
 import sys
 import itertools
-from typing import Optional, Tuple, Iterator, List
+from typing import Optional, Tuple, Iterator, List, Any
 from weakref import ReferenceType
 import weakref
 import logging
@@ -1518,7 +1518,7 @@ class Iovec(ctypes.Structure):
 
     _fields_ = [("iov_base", ctypes.c_void_p), ("iov_len", ctypes.c_size_t)]
 
-    def __init__(self, base: bytes = None, length: int = 0):
+    def __init__(self, base: Optional[bytes] = None, length: int = 0):
         if length < 0:
             raise ValueError("length must be 0 or positive")
         if length == 0 and base:
@@ -1609,7 +1609,7 @@ class TXN:
     """
 
     def __init__(
-        self, env: Env, parent: TXN = None, flags: MDBXTXNFlags = 0, context=None
+        self, env: Env, parent: Optional[TXN] = None, flags: MDBXTXNFlags = 0, context=None
     ):
         """
 
@@ -1842,7 +1842,7 @@ class TXN:
 
     def create_map(
         self,
-        name: str | bytes | None = None,
+        name: Optional[str | bytes | None] = None,
         flags: MDBXDBFlags = MDBXDBFlags.MDBX_CREATE,
     ):
         """
@@ -1860,7 +1860,7 @@ class TXN:
 
     def open_map(
         self,
-        name: str | bytes | None = None,
+        name: Optional[str | bytes | None] = None,
         flags: MDBXDBFlags = MDBXDBFlags.MDBX_DB_DEFAULTS,
     ):
         """
@@ -1988,11 +1988,11 @@ class Env(object):
         path: str,
         flags: MDBXEnvFlags = 0,
         mode: MDBXMode = 0o755,
-        geometry: Geometry = None,
+        geometry: Optional[Geometry] = None,
         maxreaders: int = 1,
         maxdbs: int = 1,
-        sync_bytes: int = None,
-        sync_period: int = None,
+        sync_bytes: Optional[int] = None,
+        sync_period: Optional[int] = None,
     ):
         self._env = ctypes.pointer(MDBXEnv())
         ret = _lib.mdbx_env_create(ctypes.byref(self._env))
@@ -2161,7 +2161,7 @@ class Env(object):
     def rw_transaction(self) -> TXN:
         return self.start_transaction(MDBXTXNFlags.MDBX_TXN_READWRITE, None)
 
-    def start_transaction(self, flags: MDBXTXNFlags = 0, parent_txn: TXN = None):
+    def start_transaction(self, flags: MDBXTXNFlags = 0, parent_txn: Optional[TXN] = None):
         """
         Starts a transaction on the given Env
 
@@ -2673,7 +2673,7 @@ class DBI:
             ]
         )
 
-    def delete(self, txn: TXN, key: bytes, value: bytes = None):
+    def delete(self, txn: TXN, key: bytes, value: Optional[bytes] = None):
         """
         Thin wrapper around mdbx_del
 
@@ -2704,7 +2704,7 @@ class Cursor:
     Used for iterating over values within a key
     """
 
-    def __init__(self, db: DBI = None, txn: TXN = None, ctx=None):
+    def __init__(self, db: Optional[DBI] = None, txn: Optional[TXN] = None, ctx: Optional[Any] = None):
         """
         Thin wrapper around either mdbx_cursor_open or mdbx_cursor_create
 
@@ -2737,7 +2737,7 @@ class Cursor:
         if txn:
             txn._dependents.append(weakref.ref(self))
 
-    def bind(self, txn: TXN, db: DBI = None):
+    def bind(self, txn: TXN, db: Optional[DBI] = None):
         """
         Thin wrapper around mdbx_cursor_bind
 

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1609,7 +1609,7 @@ class TXN:
     """
 
     def __init__(
-        self, env: Env, parent: Optional[TXN] = None, flags: MDBXTXNFlags = 0, ctx: Optional[Any] = None
+        self, env: Env, parent: Optional[TXN] = None, flags: MDBXTXNFlags = MDBXTXNFlags.MDBX_TXN_READWRITE, ctx: Optional[Any] = None
     ):
         """
 
@@ -2161,7 +2161,7 @@ class Env(object):
     def rw_transaction(self) -> TXN:
         return self.start_transaction(MDBXTXNFlags.MDBX_TXN_READWRITE, None)
 
-    def start_transaction(self, flags: MDBXTXNFlags = 0, parent_txn: Optional[TXN] = None):
+    def start_transaction(self, flags: MDBXTXNFlags = MDBXTXNFlags.MDBX_TXN_READWRITE, parent_txn: Optional[TXN] = None):
         """
         Starts a transaction on the given Env
 

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1877,13 +1877,13 @@ class TXN:
         if self._txn:
             dbi = ctypes.c_uint32()
             dbi.value = 0
+            cname: Optional[bytes]
             if isinstance(name, str):
                 cname = name.encode("utf-8")
             else:
                 cname = name
-            if cname:
-                cname = ctypes.c_char_p(cname)
-            ret = _lib.mdbx_dbi_open(self._txn, cname, flags, ctypes.pointer(dbi))
+            bname = ctypes.c_char_p(cname) if cname else None
+            ret = _lib.mdbx_dbi_open(self._txn, bname, flags, ctypes.pointer(dbi))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
             ret = DBI(self._env, MDBXDBI(dbi))

--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -1624,7 +1624,7 @@ class TXN:
         :type context: Object
         """
         self._txn = ctypes.POINTER(MDBXTXN)()
-        self._env = env
+        self._env: Env | None = env
         self._ctx: Optional[Any] = ctx
         self._flags = flags
         self._dependents: List[ReferenceType[Cursor]] = []
@@ -1886,6 +1886,9 @@ class TXN:
             ret = _lib.mdbx_dbi_open(self._txn, bname, flags, ctypes.pointer(dbi))
             if ret != MDBXError.MDBX_SUCCESS.value:
                 raise make_exception(ret)
+
+            # self._env should never be None, but like self._tnx will be None upon close
+            assert self._env
             ret = DBI(self._env, MDBXDBI(dbi))
             return ret
         return False

--- a/tests/test_iters.py
+++ b/tests/test_iters.py
@@ -8,18 +8,18 @@ import struct
 
 class MDBXIterTest(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self._folder = tempfile.TemporaryDirectory()
         self._folder_path = Path(self._folder.name)
         return super().setUp()
 
-    def test_iters(self):
+    def test_iters(self) -> None:
         expected = []
         for i in range(10):
             if i == 1:
                 continue
             expected.append((struct.pack(">I", i), struct.pack(">I", 10 - i)))
-        with Env(self._folder_path.absolute()) as env:
+        with Env(self._folder_path.absolute().as_posix()) as env:
             with env.rw_transaction() as txn:
                 with txn.open_map() as dbi:
                     for k, v in expected:
@@ -41,7 +41,7 @@ class MDBXIterTest(unittest.TestCase):
                     vals = [(k, v) for k, v in cur.iter(start_key=struct.pack(">I", 4))]
                     self.assertEqual(vals, expected[3:])
 
-    def test_iters_dup(self):
+    def test_iters_dup(self) -> None:
         expected = []
         for i in range(10):
             if i == 1:
@@ -49,7 +49,7 @@ class MDBXIterTest(unittest.TestCase):
             dups = [struct.pack(">I", x) for x in range(5)]
             expected.append((struct.pack(">I", i), tuple(dups)))
 
-        with Env(self._folder_path.absolute(), maxdbs=2) as env:
+        with Env(self._folder_path.absolute().as_posix(), maxdbs=2) as env:
             with env.rw_transaction() as txn:
                 with txn.create_map("test", MDBXDBFlags.MDBX_DUPSORT) as dbi:
                     for k, dups in expected:
@@ -94,7 +94,7 @@ class MDBXIterTest(unittest.TestCase):
                     expected = [(x, dup) for x, dups in expected for dup in dups]
                     self.assertEqual(vals, expected)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         del self._folder
         shutil.rmtree(self._folder_path, ignore_errors=True)
         return super().tearDown()

--- a/tests/test_iters.py
+++ b/tests/test_iters.py
@@ -2,7 +2,7 @@ import unittest
 import tempfile
 import shutil
 from pathlib import Path
-from mdbx import *
+from mdbx import Env, MDBXDBFlags
 import struct
 
 

--- a/tests/test_mdbx.py
+++ b/tests/test_mdbx.py
@@ -18,8 +18,6 @@ import random
 import unittest
 import os
 import string
-import threading
-import time
 import tempfile
 import mdbx
 import logging
@@ -45,7 +43,7 @@ class TestMdbx(unittest.TestCase):
 
     def test_open(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        _db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
 
     def test_write(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
@@ -298,6 +296,8 @@ class TestMdbx(unittest.TestCase):
         txn.renew()
 
     # def test_hsr(self):
+    #   import threading
+    #   import time
     #   # Need to think this all over first before a situation can be caused when the HSR function would be called
     #   # can not test reasonably for equality of returned function ptr of get_hsr and set_hsr because
     #   # the objects can not be compared for equality and the function pointer is not accessible

--- a/tests/test_mdbx.py
+++ b/tests/test_mdbx.py
@@ -21,7 +21,7 @@ import string
 import threading
 import time
 import tempfile
-import mdbx as libmdbx
+import mdbx
 import logging
 
 
@@ -45,11 +45,11 @@ class TestMdbx(unittest.TestCase):
 
     def test_open(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
 
     def test_write(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
         txn = db.start_transaction()
         dbi = txn.open_map()
         dbi.put(txn, MDBX_TEST_KEY, MDBX_TEST_VAL_BINARY)
@@ -66,14 +66,14 @@ class TestMdbx(unittest.TestCase):
 
     def test_db_readitem_writeitem(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
         db[MDBX_TEST_KEY] = MDBX_TEST_VAL_UTF8
         self.assertEqual(db[MDBX_TEST_KEY], MDBX_TEST_VAL_UTF8)
         db.close()
 
     def test_db_iter(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
         db_pairs = {}
         txn = db.start_transaction()
         for i in range(15):
@@ -91,8 +91,8 @@ class TestMdbx(unittest.TestCase):
         del dbi
         del db
         # read all keys and compare
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
-        txn = db.start_transaction(flags=libmdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
+        txn = db.start_transaction(flags=mdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
         for db_name, pairs in db_pairs.items():
             dbi = txn.open_map(db_name)
             for key, val in pairs:
@@ -101,7 +101,7 @@ class TestMdbx(unittest.TestCase):
 
     def test_success_close_written_map(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
         txn = db.start_transaction()
         opened_map = txn.create_map(MDBX_TEST_DB_NAME)
         opened_map.put(txn, MDBX_TEST_KEY, MDBX_TEST_VAL_UTF8)
@@ -111,8 +111,8 @@ class TestMdbx(unittest.TestCase):
 
     def test_multi_write(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        geo = libmdbx.Geometry(-1, -1, 2147483648, -1, -1, -1)
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024, geometry=geo)
+        geo = mdbx.Geometry(-1, -1, 2147483648, -1, -1, -1)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024, geometry=geo)
         generated_db_names = {}
         for i in range(16):
             name = id_generator().encode("utf-8")
@@ -133,8 +133,8 @@ class TestMdbx(unittest.TestCase):
         txn.commit()
         db.close()
 
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
-        txn = db.start_transaction(libmdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
+        txn = db.start_transaction(mdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
         for name in generated_db_names:
             ref = generated_db_names[name]
             dbi = txn.open_map(name)
@@ -146,7 +146,7 @@ class TestMdbx(unittest.TestCase):
 
     def test_replace(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
         txn = db.start_transaction()
         dbi = txn.open_map()
         dbi.put(txn, MDBX_TEST_KEY, MDBX_TEST_VAL_BINARY)
@@ -167,9 +167,9 @@ class TestMdbx(unittest.TestCase):
 
     def test_delete(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        db = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
+        db = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1024)
         txn = db.rw_transaction()
-        dbi = txn.create_map("multi", libmdbx.MDBXDBFlags.MDBX_DUPSORT)
+        dbi = txn.create_map("multi", mdbx.MDBXDBFlags.MDBX_DUPSORT)
         dbi.put(txn, MDBX_TEST_KEY, MDBX_TEST_VAL_BINARY)
         dbi.put(txn, MDBX_TEST_KEY, MDBX_TEST_VAL_UTF8)
         txn.commit()
@@ -189,18 +189,18 @@ class TestMdbx(unittest.TestCase):
         """
 
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        env = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        env = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
         env.register_thread()
         txn = env.start_transaction()
         stats = env.get_stat(txn)
-        self.assertIsInstance(stats, libmdbx.MDBXStat)
+        self.assertIsInstance(stats, mdbx.MDBXStat)
         self.assertTrue(str(stats))
         envinfo = env.get_info(txn)
-        self.assertIsInstance(envinfo, libmdbx.MDBXEnvinfo)
+        self.assertIsInstance(envinfo, mdbx.MDBXEnvinfo)
         self.assertTrue(str(envinfo))
 
         ret_env = txn.get_env()
-        self.assertIsInstance(ret_env, libmdbx.Env)
+        self.assertIsInstance(ret_env, mdbx.Env)
 
         dbi = txn.open_map()
         dbi.put(txn, MDBX_TEST_KEY, MDBX_TEST_VAL_UTF8)
@@ -211,8 +211,8 @@ class TestMdbx(unittest.TestCase):
             with open(path, "w") as fd:
                 env.copy2fd(
                     fd,
-                    libmdbx.MDBXCopyMode.MDBX_CP_DEFAULTS
-                    | libmdbx.MDBXCopyMode.MDBX_CP_FORCE_DYNAMIC_SIZE,
+                    mdbx.MDBXCopyMode.MDBX_CP_DEFAULTS
+                    | mdbx.MDBXCopyMode.MDBX_CP_FORCE_DYNAMIC_SIZE,
                 )
 
             self.assertTrue(os.path.exists(path))
@@ -226,7 +226,7 @@ class TestMdbx(unittest.TestCase):
 
         env.close()
 
-        env = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        env = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
         txn = env.start_transaction()
         dbi = txn.open_map()
         if sys.platform != "win32":
@@ -242,9 +242,9 @@ class TestMdbx(unittest.TestCase):
         env.get_maxkeysize()
         env.get_maxvalsize()
 
-        env.set_option(libmdbx.MDBXOption.MDBX_opt_txn_dp_initial, 2048)
+        env.set_option(mdbx.MDBXOption.MDBX_opt_txn_dp_initial, 2048)
         self.assertEqual(
-            env.get_option(libmdbx.MDBXOption.MDBX_opt_txn_dp_initial), 2048
+            env.get_option(mdbx.MDBXOption.MDBX_opt_txn_dp_initial), 2048
         )
 
         env.get_fd()
@@ -255,7 +255,7 @@ class TestMdbx(unittest.TestCase):
 
     def test_userctx(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        env = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        env = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
 
         test_obj = {"foo": "bar"}
         env.set_user_ctx(test_obj)
@@ -290,8 +290,8 @@ class TestMdbx(unittest.TestCase):
 
     def test_txn(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        env = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
-        txn = env.start_transaction(libmdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
+        env = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        txn = env.start_transaction(mdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
 
         txn.reset()
 
@@ -303,7 +303,7 @@ class TestMdbx(unittest.TestCase):
     #   # the objects can not be compared for equality and the function pointer is not accessible
     #   # Also, this test currently doesn't do anything useful
     #   return
-    #   def hsr_func(env: ctypes.POINTER(libmdbx.MDBXEnv), txn: ctypes.POINTER(libmdbx.MDBXTXN), pid: ctypes.c_int, tid: ctypes.c_int, laggard: ctypes.c_uint64, gap: ctypes.c_uint, space: ctypes.c_size_t, retry: ctypes.c_int) -> ctypes.c_int:
+    #   def hsr_func(env: ctypes.POINTER(mdbx.MDBXEnv), txn: ctypes.POINTER(mdbx.MDBXTXN), pid: ctypes.c_int, tid: ctypes.c_int, laggard: ctypes.c_uint64, gap: ctypes.c_uint, space: ctypes.c_size_t, retry: ctypes.c_int) -> ctypes.c_int:
     #       print("hsr_func called")
     #       shared.append({"pid" : pid, "tid" : tid, "laggard" : laggard, "gap" : gap, "space" : space, "retry" : retry })
     #       with condition:
@@ -311,16 +311,16 @@ class TestMdbx(unittest.TestCase):
 
     #   def stall(**kw_args):
     #       # This function needs to
-    #       env=libmdbx.Env(kw_args["env_name"], maxdbs=1)
-    #       txn=env.start_transaction(libmdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
+    #       env=mdbx.Env(kw_args["env_name"], maxdbs=1)
+    #       txn=env.start_transaction(mdbx.MDBXTXNFlags.MDBX_TXN_RDONLY)
     #       time.sleep(5)
     #       txn.abort()
 
     #   MDBX_TEST_DB_DIR="%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
     #   # Set low space limit and write it until it's full, then start read transaction and a second write transaction,
 
-    #   env=libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
-    #   env.set_hsr(libmdbx._lib.MDBX_hsr_func(hsr_func))
+    #   env=mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+    #   env.set_hsr(mdbx._lib.MDBX_hsr_func(hsr_func))
 
     #   shared = []
     #   condition=threading.Condition()
@@ -337,28 +337,28 @@ class TestMdbx(unittest.TestCase):
     # #   def rls_func()
 
     def test_get_build_info(self):
-        libmdbx.get_build_info()
+        mdbx.get_build_info()
 
     def test_get_version_info(self):
-        libmdbx.get_version_info()
+        mdbx.get_version_info()
 
     def test_get_sysram(self):
         try:
-            libmdbx._lib.mdbx_get_sysraminfo
-        except:
+            mdbx._lib.mdbx_get_sysraminfo
+        except Exception:
             return True
         a = ctypes.c_int()
         b = ctypes.c_int()
         c = ctypes.c_int()
         self.assertFalse(
-            libmdbx._lib.mdbx_get_sysraminfo(
+            mdbx._lib.mdbx_get_sysraminfo(
                 ctypes.byref(a), ctypes.byref(b), ctypes.byref(c)
             )
         )
 
     def test_txnid(self):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        env = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        env = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
 
         txn = env.start_transaction()
         self.assertTrue(txn.id())
@@ -367,13 +367,13 @@ class TestMdbx(unittest.TestCase):
         return
         # Haven't succeeded in making this work
         # MDBX_TEST_DB_DIR="%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
-        # env=libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
+        # env=mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=1)
 
         # txn=env.start_transaction()
 
         # dbi=txn.open_map()
 
-        # cursor=libmdbx.Cursor()
+        # cursor=mdbx.Cursor()
         # cursor.bind(txn, dbi)
         # cursor.put(MDBX_TEST_KEY, MDBX_TEST_VAL_UTF8)
         # self.assertEqual(MDBX_TEST_VAL_UTF8, cursor.get(MDBX_TEST_KEY))
@@ -386,18 +386,18 @@ class TestMdbx(unittest.TestCase):
         MDBX_TEST_DB_DIR = "%s/%s" % (MDBX_TEST_DIR, inspect.stack()[0][3])
         a = "abc".encode("utf-8")
         b = "def".encode("utf-8")
-        env = libmdbx.Env(MDBX_TEST_DB_DIR, maxdbs=2)
+        env = mdbx.Env(MDBX_TEST_DB_DIR, maxdbs=2)
 
         txn = env.start_transaction()
 
-        dbi = txn.open_map(MDBX_TEST_DB_NAME, flags=libmdbx.MDBXDBFlags.MDBX_CREATE)
+        dbi = txn.open_map(MDBX_TEST_DB_NAME, flags=mdbx.MDBXDBFlags.MDBX_CREATE)
 
-        cursor = libmdbx.Cursor(dbi, txn)
+        cursor = mdbx.Cursor(dbi, txn)
 
         cursor.put(MDBX_TEST_KEY, MDBX_TEST_VAL_UTF8)
         self.assertEqual(MDBX_TEST_VAL_UTF8, cursor.get(MDBX_TEST_KEY))
-        # with self.assertRaises(libmdbx.MDBXErrorExc):
-        cursor.get(MDBX_TEST_KEY, libmdbx.MDBXCursorOp.MDBX_FIRST)
+        # with self.assertRaises(mdbx.MDBXErrorExc):
+        cursor.get(MDBX_TEST_KEY, mdbx.MDBXCursorOp.MDBX_FIRST)
 
         cursor.get(a)
         cursor.put(a, b)
@@ -407,21 +407,21 @@ class TestMdbx(unittest.TestCase):
             f"Status, txn={txn._txn}, cursor={cursor._cursor}, dbi={dbi._dbi}"
         )
         txn = env.start_transaction()
-        logging.getLogger("mdbx").debug(f"New dbi")
+        logging.getLogger("mdbx").debug(f"New dbi, dbi = {dbi._dbi}")
         dbi = txn.open_map(MDBX_TEST_DB_NAME)
         logging.getLogger("mdbx").debug(f"New Cursor, dbi = {dbi._dbi}")
-        cursor = libmdbx.Cursor(dbi, txn)
+        cursor = mdbx.Cursor(dbi, txn)
         self.assertEqual(MDBX_TEST_VAL_UTF8, dbi.get(txn, MDBX_TEST_KEY))
-        self.assertEqual(b, cursor.get(a, cursor_op=libmdbx.MDBXCursorOp.MDBX_SET))
+        self.assertEqual(b, cursor.get(a, cursor_op=mdbx.MDBXCursorOp.MDBX_SET))
 
-        cursor.get(MDBX_TEST_KEY, libmdbx.MDBXCursorOp.MDBX_NEXT)
+        cursor.get(MDBX_TEST_KEY, mdbx.MDBXCursorOp.MDBX_NEXT)
 
-        cursor.get(MDBX_TEST_KEY, libmdbx.MDBXCursorOp.MDBX_NEXT)
+        cursor.get(MDBX_TEST_KEY, mdbx.MDBXCursorOp.MDBX_NEXT)
         self.assertTrue(cursor.eof())
-        cursor.get(MDBX_TEST_KEY, libmdbx.MDBXCursorOp.MDBX_FIRST)
+        cursor.get(MDBX_TEST_KEY, mdbx.MDBXCursorOp.MDBX_FIRST)
         self.assertTrue(cursor.on_first())
         self.assertFalse(cursor.on_last())
-        cursor.get(MDBX_TEST_KEY, libmdbx.MDBXCursorOp.MDBX_LAST)
+        cursor.get(MDBX_TEST_KEY, mdbx.MDBXCursorOp.MDBX_LAST)
         self.assertTrue(cursor.on_last())
         self.assertFalse(cursor.on_first())
         cursor.delete()

--- a/tests/test_mdbx.py
+++ b/tests/test_mdbx.py
@@ -295,6 +295,8 @@ class TestMdbx(unittest.TestCase):
 
         txn.renew()
 
+        self.assertEqual(txn.get_info().txn_id, 3) # Maybe this is a bit too naive
+
     # def test_hsr(self):
     #   import threading
     #   import time


### PR DESCRIPTION
Every function is ran against black, ruff and mypy.

I think we should still do some work to make sure that the get and iter functions will not result "None, None" depending if that is feasible from mdbx. I think it would make the code checking a lot safer, and less bytes|None, bytes|None.

There have been made some significant changes, including evident bug fixes. I would suggest, if merged, **not** to squash, but keep the individual commits.