### PR TITLE
Windows enum fixes

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Build SDist
         run: |
           sudo apt update && sudo apt install ninja-build git build-essential -y
-          cd libmdbx && git fetch --tags && make V=1 dist && cd ..
+          cd libmdbx && git fetch --tags && make V=1 && cd ..
           python3 -m pip install -U pip build
           python3 -m build --sdist
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libmdbx"]
 	path = libmdbx
-	url = https://github.com/erthink/libmdbx
+	url = https://gitflic.ru/project/erthink/libmdbx.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libmdbx"]
 	path = libmdbx
-	url = https://gitflic.ru/project/erthink/libmdbx.git
+	url = https://github.com/erthink/libmdbx

--- a/build_mdbx.py
+++ b/build_mdbx.py
@@ -35,7 +35,7 @@ def build(setup_kws: dict):
     # If there is already dist
     if not dist_folder.exists():
         if sys.platform in ["linux", "linux2"]:
-            subprocess.check_call(["make", "dist"], cwd=libmdbx_source)
+            subprocess.check_call(["make"], cwd=libmdbx_source)
     
     if have_git() and (libmdbx_source / ".git").exists():
         source_folder = libmdbx_source

--- a/platform_enums.c
+++ b/platform_enums.c
@@ -1,0 +1,20 @@
+#include "libmdbx/mdbx.h"
+#include <stdio.h>
+
+int main(void) {
+    printf("{\n");
+    printf("  \"MDBX_SUCCESS\": %d,\n", MDBX_SUCCESS);
+    printf("  \"MDBX_ENODATA\": %d,\n", MDBX_ENODATA);
+    printf("  \"MDBX_EINVAL\": %d,\n", MDBX_EINVAL);
+    printf("  \"MDBX_EACCES\": %d,\n", MDBX_EACCESS);
+    printf("  \"MDBX_ENOMEM\": %d,\n", MDBX_ENOMEM);
+    printf("  \"MDBX_EROFS\": %d,\n", MDBX_EROFS);
+    printf("  \"MDBX_ENOSYS\": %d,\n", MDBX_ENOSYS);
+    printf("  \"MDBX_EIO\": %d,\n", MDBX_EIO);
+    printf("  \"MDBX_EPERM\": %d,\n", MDBX_EPERM);
+    printf("  \"MDBX_EINTR\": %d,\n", MDBX_EINTR);
+    printf("  \"MDBX_ENOFILE\": %d,\n", MDBX_ENOFILE);
+    printf("  \"MDBX_EREMOTE\": %d\n", MDBX_EREMOTE);
+    printf("}\n");
+    return 0;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,8 @@ packages = [
     {include = "mdbx"}
 ]
 include = [
-    { path = "libmdbx/dist/*", format = "sdist"},
+    { path = "libmdbx/*", format = "sdist"},
     { path = "mdbx/lib/*", format = "wheel" },
-]
-
-exclude = [
-    { path = "libmdbx/dist/build", format = "sdist"},
 ]
 
 [tool.poetry.build]


### PR DESCRIPTION
This uses a C binary to get the 'true' values from the enums. We might do the same for all other enum values, but this was the only thing I found to be dynamic within mdbx.

Want to see if the tests run on all platforms.