### PR TITLE
Fix tests

### DIFF
--- a/mdbx/mdbx.py
+++ b/mdbx/mdbx.py
@@ -3713,15 +3713,12 @@ _lib.mdbx_is_readahead_reasonable.argtypes = [
 ]
 _lib.mdbx_is_readahead_reasonable.restype = ctypes.c_int
 
-try:
-    _lib.mdbx_get_sysraminfo.argtypes = [
-        ctypes.POINTER(ctypes.c_int),
-        ctypes.POINTER(ctypes.c_int),
-        ctypes.POINTER(ctypes.c_int),
-    ]
-    _lib.mdbx_get_sysraminfo.restype = ctypes.c_int
-except:  # noqa: E722
-    pass
+_lib.mdbx_get_sysraminfo.argtypes = [
+    ctypes.POINTER(ctypes.c_int),
+    ctypes.POINTER(ctypes.c_int),
+    ctypes.POINTER(ctypes.c_int),
+]
+_lib.mdbx_get_sysraminfo.restype = ctypes.c_int
 
 _lib.mdbx_is_dirty.argtypes = [ctypes.POINTER(MDBXTXN), ctypes.c_void_p]
 _lib.mdbx_is_dirty.restype = ctypes.c_int

--- a/tests/test_iters.py
+++ b/tests/test_iters.py
@@ -122,8 +122,7 @@ class MDBXIterTest(unittest.TestCase):
                     self.assertEqual(dbi.get_sequence(txn, 0), 2)
 
     def tearDown(self):
-        del self._folder
-        shutil.rmtree(self._folder_path, ignore_errors=True)
+        self._folder.cleanup()
         return super().tearDown()
 
 


### PR DESCRIPTION
Fix tests (hygiene). In addition make mdbx_get_sysraminfo always available. Lets hope all platforms agree.